### PR TITLE
Fix bouncing arrow on Safari

### DIFF
--- a/roestigraben.html
+++ b/roestigraben.html
@@ -122,7 +122,7 @@
       transform: translateY(20px);
       transition: opacity 0.6s ease-out, transform 0.6s ease-out;
     }
-    .visible { opacity: 1 !important; transform: translateY(0) !important; }
+    .visible { opacity: 1; transform: translateY(0); }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- tweak `.visible` style in `roestigraben.html` so animation isn't overridden

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f7545efcc832db9ea20e2bdbdd7f0