### PR TITLE
Add GitHub repo link to IRL project page

### DIFF
--- a/irl.html
+++ b/irl.html
@@ -17,6 +17,11 @@
       <section class="project-intro">
         <h1>Introduction to Reinforcement Learning</h1>
         <p>Welcome to the repository for the <em>Introduction to Reinforcement Learning</em> course at <strong>Leiden University</strong>. This repository contains all assignments, each exploring a different aspect of reinforcement learning: from bandit problems and dynamic programming to model-free and model-based learning.</p>
+        <p class="repo-link">
+          <a href="https://github.com/joonhaim/intro-to-reinforcement-learning" target="_blank" rel="noopener">
+            View full project on GitHub →
+          </a>
+        </p>
       </section>
       <section>
         <h2>Authors</h2>


### PR DESCRIPTION
## Summary
- add GitHub link to Introduction to Reinforcement Learning page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c321b9128832db3252ca0f9fe4bb2