### PR TITLE
Add course link on Cognition page

### DIFF
--- a/cognition.html
+++ b/cognition.html
@@ -18,7 +18,7 @@
         <h1>Cognition &amp; Computation</h1>
         <p>
           This page is a collection of all four assignments completed for the Cognition and Computation course
-          at Leiden University (4032COGCO). The course explores key concepts in cognitive science through computational modeling.
+          at Leiden University (<a href="https://studiegids.universiteitleiden.nl/en/courses/123396/cognition-and-computation" target="_blank" rel="noopener">4032COGCO</a>). The course explores key concepts in cognitive science through computational modeling.
           This course was taught by Dr. Steven Miletić and Dr. ir. Roy de Kleijn (Leiden University, 2024–2025).
           You can find the more detailed implementations of these small projects by visiting the link below.
         </p>


### PR DESCRIPTION
## Summary
- link to the official Cognition & Computation course page

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_686c3451e07c832db111726958faddf5