### PR TITLE
Hide some projects from menu and homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,25 +110,6 @@
           </div>
         </article>
 
-        <!-- Atmosphere Calculator -->
-        <article class="project">
-          <img
-            src="static/images/logos/atmosphere.png"
-            alt="Atmosphere Calculator logo"
-            class="project-logo"
-            loading="lazy"
-          >
-          <div class="project-details">
-            <h3>Atmosphere Calculator</h3>
-            <p>
-              Originally developed for Aerospace Engineering assignments at
-              TU Delft, this tool computes atmospheric temperature, pressure,
-              and density up to 47,000 m. Try the mini version below or visit
-              the full version for more details.
-            </p>
-            <a href="atmosphere.html">Explore Full Calculator →</a>
-          </div>
-        </article>
         <p><br>You can find all of my projects on my GitHub Profile:</p>
         <a href="https://github.com/joonhaim" class="cta-link" target="_blank">GitHub Profile →</a>
       </section>

--- a/partials/header.html
+++ b/partials/header.html
@@ -12,11 +12,9 @@
         <li class="has-dropdown">
           <a href="projects.html">Projects<span class="arrow">▾</span></a>
           <ul class="dropdown-menu">
-            <li><a href="roestigraben.html">Beyond the Röstigraben (Preview)</a></li>
             <li><a href="easysave.html">EasySave</a></li>
             <li><a href="cognition.html">Cognition and Computation</a></li>
             <li><a href="irl.html">Introduction to Reinforcement Learning</a></li>
-            <li><a href="atmosphere.html">AtmosphereCalculator</a></li>
             <li><a href="projects.html">All Projects →</a></li>
           </ul>
         </li>


### PR DESCRIPTION
## Summary
- simplify the Projects dropdown
- remove AtmosphereCalculator from the homepage listing

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d7549f788832d9064b8e8ae1a314f