### PR TITLE
Fix custom 404 styling for subpaths

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,9 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>404 – Page Not Found</title>
-  <link rel="stylesheet" href="static/css/styles.css">
-  <script src="static/js/script.js" defer></script>
-  <script src="static/js/includes.js" defer></script>
+  <!-- use root-relative paths so this page works from any URL -->
+  <link rel="stylesheet" href="/static/css/styles.css">
+  <script src="/static/js/script.js" defer></script>
+  <script src="/static/js/includes.js" defer></script>
   <style>
     .error-container { text-align:center; padding: var(--space-xl) 0; }
     .error-container h1 { font-size: 4rem; margin-bottom: var(--space-md); }

--- a/static/js/includes.js
+++ b/static/js/includes.js
@@ -6,8 +6,9 @@ document.addEventListener('DOMContentLoaded', () => {
         .catch(err => console.error(`Error loading ${url}:`, err));
   
     // inject header & footer
-    const headerLoaded = load('#site-header', 'partials/header.html');
-    load('#site-footer', 'partials/footer.html');
+    // use absolute paths so includes load even when the page URL is nested
+    const headerLoaded = load('#site-header', '/partials/header.html');
+    load('#site-footer', '/partials/footer.html');
 
   // once header is in place, highlight active link and enable mobile nav
   headerLoaded.then(() => {


### PR DESCRIPTION
## Summary
- update 404 page to use root-relative asset paths
- load header and footer using absolute URLs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d77621470832dbc91794b58f6e915