### PR TITLE
Add PDF generation for profile CV

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -9,6 +9,8 @@
   <link rel='stylesheet' href='static/css/styles.css'>
   <script src='static/js/script.js' defer></script>
   <script src='static/js/includes.js' defer></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.9.3/html2pdf.bundle.min.js'></script>
+  <script src='static/js/generateCV.js' defer></script>
 
   <!-- page‑specific tweaks -->
   <style>
@@ -43,6 +45,9 @@
     text-align:left;
     margin:0;
   }
+  #download-cv{padding:0.75rem 1.5rem;font:inherit;font-weight:500;border:none;background:#000;color:#fff;cursor:pointer;margin-bottom:var(--space-lg);}
+  #download-cv:hover{opacity:0.85;}
+
   </style>
 </head>
 
@@ -62,6 +67,8 @@
           <p><strong>Email </strong><a href='mailto:a.j.im@umail.leidenuniv.nl'>a.j.im@umail.leidenuniv.nl</a></p>
         </div>
       </section>
+      <button id="download-cv">Download PDF CV</button>
+
 
       <!-- Education -->
       <section id='education' class='cv-section'>

--- a/static/js/generateCV.js
+++ b/static/js/generateCV.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('download-cv');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    const element = document.querySelector('main');
+    if (!element) return;
+    const opt = {
+      margin:       0.5,
+      filename:     'Adrien_Joon-Ha_Im_CV.pdf',
+      image:        { type: 'jpeg', quality: 0.98 },
+      html2canvas:  { scale: 2 },
+      jsPDF:        { unit: 'in', format: 'a4', orientation: 'portrait' }
+    };
+    html2pdf().set(opt).from(element).save();
+  });
+});


### PR DESCRIPTION
## Summary
- add html2pdf and custom JS for generating a PDF CV
- style a download button on profile page
- include download button on the profile page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e6ee7c068832d8bcb1821a2569c10