### PR TITLE
Redesign Roestigraben language switcher

### DIFF
--- a/roestigraben.html
+++ b/roestigraben.html
@@ -13,10 +13,10 @@
 </head>
 <body>
   <div class="language-switcher">
-    <a href="roestigraben_de.html">DE</a> |
-    <a href="roestigraben_fr.html">FR</a> |
-    <a href="roestigraben_it.html">IT</a> |
-    <span class="active">EN</span>
+    <a href="roestigraben_de.html" class="lang-btn">DE</a>
+    <a href="roestigraben_fr.html" class="lang-btn">FR</a>
+    <a href="roestigraben_it.html" class="lang-btn">IT</a>
+    <span class="lang-btn active">EN</span>
   </div>
   <div class="swiss-cross"></div>
 

--- a/roestigraben_de.html
+++ b/roestigraben_de.html
@@ -13,10 +13,10 @@
 </head>
 <body>
   <div class="language-switcher">
-    <span class="active">DE</span> |
-    <a href="roestigraben_fr.html">FR</a> |
-    <a href="roestigraben_it.html">IT</a> |
-    <a href="roestigraben.html">EN</a>
+    <span class="lang-btn active">DE</span>
+    <a href="roestigraben_fr.html" class="lang-btn">FR</a>
+    <a href="roestigraben_it.html" class="lang-btn">IT</a>
+    <a href="roestigraben.html" class="lang-btn">EN</a>
   </div>
   <div class="swiss-cross"></div>
 

--- a/roestigraben_fr.html
+++ b/roestigraben_fr.html
@@ -13,10 +13,10 @@
 </head>
 <body>
   <div class="language-switcher">
-    <a href="roestigraben_de.html">DE</a> |
-    <span class="active">FR</span> |
-    <a href="roestigraben_it.html">IT</a> |
-    <a href="roestigraben.html">EN</a>
+    <a href="roestigraben_de.html" class="lang-btn">DE</a>
+    <span class="lang-btn active">FR</span>
+    <a href="roestigraben_it.html" class="lang-btn">IT</a>
+    <a href="roestigraben.html" class="lang-btn">EN</a>
   </div>
   <div class="swiss-cross"></div>
 

--- a/roestigraben_it.html
+++ b/roestigraben_it.html
@@ -13,10 +13,10 @@
 </head>
 <body>
   <div class="language-switcher">
-    <a href="roestigraben_de.html">DE</a> |
-    <a href="roestigraben_fr.html">FR</a> |
-    <span class="active">IT</span> |
-    <a href="roestigraben.html">EN</a>
+    <a href="roestigraben_de.html" class="lang-btn">DE</a>
+    <a href="roestigraben_fr.html" class="lang-btn">FR</a>
+    <span class="lang-btn active">IT</span>
+    <a href="roestigraben.html" class="lang-btn">EN</a>
   </div>
   <div class="swiss-cross"></div>
 

--- a/static/css/roestigraben.css
+++ b/static/css/roestigraben.css
@@ -17,16 +17,27 @@ body {
   top: 1rem;
   left: 1rem;
   z-index: 10;
+  display: flex;
+  gap: 0.25rem;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 0.25rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
-.language-switcher a,
-.language-switcher span {
-  margin: 0 0.5rem;
+.language-switcher .lang-btn {
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
   text-decoration: none;
   color: #000;
-  font-weight: bold;
+  font-weight: 600;
+  transition: background-color 0.3s;
+}
+.language-switcher .lang-btn:hover {
+  background-color: rgba(0, 0, 0, 0.1);
 }
 .language-switcher .active {
-  text-decoration: underline;
+  background-color: #000;
+  color: #fff;
 }
 /* Swiss cross in corner */
 .swiss-cross {


### PR DESCRIPTION
## Summary
- Style language toggle as pill buttons with hover and active states
- Update all Roestigraben language pages to use new toggle markup

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68959d09ddc0832da78908167ea8dc0f