### PR TITLE
Redesign Roestigraben language switcher

### DIFF
--- a/roestigraben.html
+++ b/roestigraben.html
@@ -13,10 +13,11 @@
 </head>
 <body>
   <div class="language-switcher">
-    <a href="roestigraben_de.html">DE</a> |
-    <a href="roestigraben_fr.html">FR</a> |
-    <a href="roestigraben_it.html">IT</a> |
-    <span class="active">EN</span>
+    <div class="lang-slider"></div>
+    <a href="roestigraben_de.html" class="lang-btn">DE</a>
+    <a href="roestigraben_fr.html" class="lang-btn">FR</a>
+    <a href="roestigraben_it.html" class="lang-btn">IT</a>
+    <span class="lang-btn active">EN</span>
   </div>
   <div class="swiss-cross"></div>
 
@@ -81,6 +82,29 @@
         });
       }, { threshold: 0.4 });
       sections.forEach(sec => observer.observe(sec));
+
+      const switcher = document.querySelector('.language-switcher');
+      const slider = switcher.querySelector('.lang-slider');
+      const buttons = switcher.querySelectorAll('.lang-btn');
+      const activeBtn = switcher.querySelector('.active');
+      const padding = parseFloat(getComputedStyle(switcher).paddingLeft);
+
+      function moveSlider(btn) {
+        slider.style.width = btn.offsetWidth + 'px';
+        slider.style.transform = `translateX(${btn.offsetLeft - padding}px)`;
+      }
+
+      moveSlider(activeBtn);
+
+      buttons.forEach(btn => {
+        if (btn.tagName === 'A') {
+          btn.addEventListener('click', e => {
+            e.preventDefault();
+            moveSlider(btn);
+            setTimeout(() => { window.location.href = btn.href; }, 300);
+          });
+        }
+      });
     });
   </script>
 </body>

--- a/roestigraben_de.html
+++ b/roestigraben_de.html
@@ -13,10 +13,11 @@
 </head>
 <body>
   <div class="language-switcher">
-    <span class="active">DE</span> |
-    <a href="roestigraben_fr.html">FR</a> |
-    <a href="roestigraben_it.html">IT</a> |
-    <a href="roestigraben.html">EN</a>
+    <div class="lang-slider"></div>
+    <span class="lang-btn active">DE</span>
+    <a href="roestigraben_fr.html" class="lang-btn">FR</a>
+    <a href="roestigraben_it.html" class="lang-btn">IT</a>
+    <a href="roestigraben.html" class="lang-btn">EN</a>
   </div>
   <div class="swiss-cross"></div>
 
@@ -81,6 +82,29 @@
         });
       }, { threshold: 0.4 });
       sections.forEach(sec => observer.observe(sec));
+
+      const switcher = document.querySelector('.language-switcher');
+      const slider = switcher.querySelector('.lang-slider');
+      const buttons = switcher.querySelectorAll('.lang-btn');
+      const activeBtn = switcher.querySelector('.active');
+      const padding = parseFloat(getComputedStyle(switcher).paddingLeft);
+
+      function moveSlider(btn) {
+        slider.style.width = btn.offsetWidth + 'px';
+        slider.style.transform = `translateX(${btn.offsetLeft - padding}px)`;
+      }
+
+      moveSlider(activeBtn);
+
+      buttons.forEach(btn => {
+        if (btn.tagName === 'A') {
+          btn.addEventListener('click', e => {
+            e.preventDefault();
+            moveSlider(btn);
+            setTimeout(() => { window.location.href = btn.href; }, 300);
+          });
+        }
+      });
     });
   </script>
 </body>

--- a/roestigraben_fr.html
+++ b/roestigraben_fr.html
@@ -13,10 +13,11 @@
 </head>
 <body>
   <div class="language-switcher">
-    <a href="roestigraben_de.html">DE</a> |
-    <span class="active">FR</span> |
-    <a href="roestigraben_it.html">IT</a> |
-    <a href="roestigraben.html">EN</a>
+    <div class="lang-slider"></div>
+    <a href="roestigraben_de.html" class="lang-btn">DE</a>
+    <span class="lang-btn active">FR</span>
+    <a href="roestigraben_it.html" class="lang-btn">IT</a>
+    <a href="roestigraben.html" class="lang-btn">EN</a>
   </div>
   <div class="swiss-cross"></div>
 
@@ -81,6 +82,29 @@
         });
       }, { threshold: 0.4 });
       sections.forEach(sec => observer.observe(sec));
+
+      const switcher = document.querySelector('.language-switcher');
+      const slider = switcher.querySelector('.lang-slider');
+      const buttons = switcher.querySelectorAll('.lang-btn');
+      const activeBtn = switcher.querySelector('.active');
+      const padding = parseFloat(getComputedStyle(switcher).paddingLeft);
+
+      function moveSlider(btn) {
+        slider.style.width = btn.offsetWidth + 'px';
+        slider.style.transform = `translateX(${btn.offsetLeft - padding}px)`;
+      }
+
+      moveSlider(activeBtn);
+
+      buttons.forEach(btn => {
+        if (btn.tagName === 'A') {
+          btn.addEventListener('click', e => {
+            e.preventDefault();
+            moveSlider(btn);
+            setTimeout(() => { window.location.href = btn.href; }, 300);
+          });
+        }
+      });
     });
   </script>
 </body>

--- a/roestigraben_it.html
+++ b/roestigraben_it.html
@@ -13,10 +13,11 @@
 </head>
 <body>
   <div class="language-switcher">
-    <a href="roestigraben_de.html">DE</a> |
-    <a href="roestigraben_fr.html">FR</a> |
-    <span class="active">IT</span> |
-    <a href="roestigraben.html">EN</a>
+    <div class="lang-slider"></div>
+    <a href="roestigraben_de.html" class="lang-btn">DE</a>
+    <a href="roestigraben_fr.html" class="lang-btn">FR</a>
+    <span class="lang-btn active">IT</span>
+    <a href="roestigraben.html" class="lang-btn">EN</a>
   </div>
   <div class="swiss-cross"></div>
 
@@ -81,6 +82,29 @@
         });
       }, { threshold: 0.4 });
       sections.forEach(sec => observer.observe(sec));
+
+      const switcher = document.querySelector('.language-switcher');
+      const slider = switcher.querySelector('.lang-slider');
+      const buttons = switcher.querySelectorAll('.lang-btn');
+      const activeBtn = switcher.querySelector('.active');
+      const padding = parseFloat(getComputedStyle(switcher).paddingLeft);
+
+      function moveSlider(btn) {
+        slider.style.width = btn.offsetWidth + 'px';
+        slider.style.transform = `translateX(${btn.offsetLeft - padding}px)`;
+      }
+
+      moveSlider(activeBtn);
+
+      buttons.forEach(btn => {
+        if (btn.tagName === 'A') {
+          btn.addEventListener('click', e => {
+            e.preventDefault();
+            moveSlider(btn);
+            setTimeout(() => { window.location.href = btn.href; }, 300);
+          });
+        }
+      });
     });
   </script>
 </body>

--- a/static/css/roestigraben.css
+++ b/static/css/roestigraben.css
@@ -17,16 +17,39 @@ body {
   top: 1rem;
   left: 1rem;
   z-index: 10;
+  display: flex;
+  gap: 0.25rem;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 0.25rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
-.language-switcher a,
-.language-switcher span {
-  margin: 0 0.5rem;
+.language-switcher .lang-btn {
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
   text-decoration: none;
   color: #000;
-  font-weight: bold;
+  font-weight: 600;
+  transition: background-color 0.3s;
+  position: relative;
+  z-index: 1;
+}
+.language-switcher .lang-btn:hover {
+  background-color: rgba(0, 0, 0, 0.1);
 }
 .language-switcher .active {
-  text-decoration: underline;
+  color: #fff;
+}
+.lang-slider {
+  position: absolute;
+  top: 0.25rem;
+  left: 0.25rem;
+  height: calc(100% - 0.5rem);
+  background-color: #000;
+  border-radius: 0.25rem;
+  transition: transform 0.3s ease, width 0.3s ease;
+  z-index: 0;
+  pointer-events: none;
 }
 /* Swiss cross in corner */
 .swiss-cross {


### PR DESCRIPTION
## Summary
- Style language toggle as pill buttons with hover and active states
- Update all Roestigraben language pages to use new toggle markup
- Animate language switcher slider for smooth transitions

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68959d09ddc0832da78908167ea8dc0f