### PR TITLE
feat: add Swiss cross home link

### DIFF
--- a/roestigraben.html
+++ b/roestigraben.html
@@ -18,7 +18,7 @@
     <a href="roestigraben_it.html" class="lang-btn">IT</a>
     <span class="lang-btn active">EN</span>
   </div>
-  <div class="swiss-cross"></div>
+  <a href="index.html" class="swiss-cross" aria-label="Back to homepage"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">
     <h1 class="fade-element">Beyond<br>the<br>Röstigraben</h1>

--- a/roestigraben_de.html
+++ b/roestigraben_de.html
@@ -18,7 +18,7 @@
     <a href="roestigraben_it.html" class="lang-btn">IT</a>
     <a href="roestigraben.html" class="lang-btn">EN</a>
   </div>
-  <div class="swiss-cross"></div>
+  <a href="index.html" class="swiss-cross" aria-label="Zur Startseite"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">
     <h1 class="fade-element">Jenseits<br>des<br>Röstigrabens</h1>

--- a/roestigraben_fr.html
+++ b/roestigraben_fr.html
@@ -18,7 +18,7 @@
     <a href="roestigraben_it.html" class="lang-btn">IT</a>
     <a href="roestigraben.html" class="lang-btn">EN</a>
   </div>
-  <div class="swiss-cross"></div>
+  <a href="index.html" class="swiss-cross" aria-label="Retour à l'accueil"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">
     <h1 class="fade-element">Au-delà<br>du<br>Röstigraben</h1>

--- a/roestigraben_it.html
+++ b/roestigraben_it.html
@@ -18,7 +18,7 @@
     <span class="lang-btn active">IT</span>
     <a href="roestigraben.html" class="lang-btn">EN</a>
   </div>
-  <div class="swiss-cross"></div>
+  <a href="index.html" class="swiss-cross" aria-label="Torna alla home page"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">
     <h1 class="fade-element">Oltre<br>il<br>Röstigraben</h1>

--- a/static/css/roestigraben.css
+++ b/static/css/roestigraben.css
@@ -46,6 +46,7 @@ body {
   right: 1rem;
   width: 2rem;
   height: 2rem;
+  display: block;
   background: white;
   clip-path: polygon(
     40% 0%, 60% 0%, 60% 40%, 100% 40%, 100% 60%, 60% 60%,
@@ -53,6 +54,13 @@ body {
   );
   box-shadow: 0 0 0 2px #000;
   z-index: 10;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.swiss-cross:hover {
+  transform: scale(1.1);
+  box-shadow: 0 0 0 2px #000, 0 2px 6px rgba(0, 0, 0, 0.2);
 }
 h1, h2 { margin: 0; line-height: 1.1; }
 h1 {


### PR DESCRIPTION
## Summary
- Make the Swiss cross a link back to the homepage on all Röstigraben pages
- Style the cross with pointer and hover effects for a minimal Swiss feel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895a02bff58832d958a3729da8093b6