### PR TITLE
Add CV download button to About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -28,7 +28,8 @@
     <main class='content'>
 
       <div class='cv-download-wrap'>
-        <button id="download-cv">Download as PDF</button>
+        <button id="download-page-pdf" class="cv-download-btn">Download page as PDF</button>
+        <a class="cv-download-btn" href="static/pdf/cv/CV_Adrien_Im.pdf" download>Download CV</a>
       </div>
 
       <!-- Hero -->

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -31,7 +31,7 @@ margin:0;
 }
 .contact-line{display:flex;flex-wrap:wrap;margin:0;}
 .cv-download-wrap{text-align:right;margin-bottom:var(--space-md);}
-#download-cv{
+.cv-download-btn{
 display:inline-block;
 padding:0.35rem 0.7rem;
 font-size:1rem;
@@ -42,8 +42,9 @@ background:#000;
 color:#fff;
 cursor:pointer;
 border-radius:0;
+text-decoration:none;
 }
-#download-cv:hover{opacity:0.85;}
+.cv-download-btn:hover{opacity:0.85;}
 main.pdf-export{font-size:0.85rem;}
-main.pdf-export #download-cv{display:none;}
+main.pdf-export .cv-download-btn{display:none;}
 

--- a/static/js/generateCV.js
+++ b/static/js/generateCV.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const btn = document.getElementById('download-cv');
+  const btn = document.getElementById('download-page-pdf');
   if (!btn) return;
   btn.addEventListener('click', () => {
     const element = document.querySelector('main');


### PR DESCRIPTION
## Summary
- Add dedicated button to download CV PDF and rename existing button to "Download page as PDF"
- Style download buttons consistently and hide them during PDF export
- Update PDF generation script for renamed button

## Testing
- `npm test >/tmp/npm-test.log 2>&1; cat /tmp/npm-test.log` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899ac9fa6c8832da87dec3215e7bf94