### PR TITLE
Move language course section to profile footer

### DIFF
--- a/about.html
+++ b/about.html
@@ -184,7 +184,7 @@
         <ul class='timeline'>
           <li>
             <div class='title'>Goethe-Institut Seoul — A1.1</div>
-            <div class='meta'>06 Mar 2023 – 26 Apr 2023 · 69 h in-person</div>
+            <div class='meta'>06 Mar 2023 – 26 Apr 2023 · 69 h in-person · <a href="static/pdf/certificates/deutsch_A1_confirmation.pdf" target="_blank">Confirmation of participation</a></div>
           </li>
           <li>
             <div class='title'>Deutsch Online Training — A2</div>

--- a/about.html
+++ b/about.html
@@ -180,8 +180,12 @@
 
       <!-- Courses -->
       <section id='courses' class='cv-section'>
-        <h2>Courses</h2>
+        <h2>Goethe-Institut Courses</h2>
         <ul class='timeline'>
+          <li>
+            <div class='title'>Goethe-Institut Seoul — A1.1</div>
+            <div class='meta'>06 Mar 2023 – 26 Apr 2023 · 69 h in-person</div>
+          </li>
           <li>
             <div class='title'>Deutsch Online Training — A2</div>
             <div class='meta'>Jul 2024 – Oct 2024 · <a href="static/pdf/certificates/deutsch_A2_certificate.pdf" target="_blank">Certificate of completion</a></div>
@@ -189,6 +193,10 @@
           <li>
             <div class='title'>Deutsch Online Training — B1</div>
             <div class='meta'>Sep 2024 – Dec 2024 · <a href="static/pdf/certificates/deutsch_B1_certificate.pdf" target="_blank">Certificate of completion</a></div>
+          </li>
+          <li>
+            <div class='title'>Deutsch Online Training — B2</div>
+            <div class='meta'>Jul 2025 – Sep 2025 · In progress</div>
           </li>
         </ul>
       </section>

--- a/about.html
+++ b/about.html
@@ -169,22 +169,27 @@
   </ul>
 </section>
 
-      <!-- Courses -->
-      <section id='courses' class='cv-section'>
-        <h2>Courses</h2>
-        <ul class='timeline'>
-          <li><div class='title'><a href="static/pdf/certificates/deutsch_A2_certificate.pdf" download>Deutsch Online Training — A2</a></div><div class='meta'>Certificate of completion</div></li>
-          <li><div class='title'><a href="static/pdf/certificates/deutsch_B1_certificate.pdf" download>Deutsch Online Training — B1</a></div><div class='meta'>Certificate of completion</div></li>
-          <li><div class='title'><a href="static/pdf/certificates/deutsch_B2_certificate.pdf" download>Deutsch Online Training — B2</a></div><div class='meta'>Certificate of completion</div></li>
-        </ul>
-      </section>
-
       <!-- Certificates -->
       <section id='certificates' class='cv-section'>
         <h2>Certificates</h2>
         <ul class='timeline'>
           <li><div class='title'>TOEIC Speaking — Score 200</div><div class='meta'>ETS · Sept 2020</div></li>
           <li><div class='title'>HSK Level 4</div><div class='meta'>Hanban Confucius Institute · Jul 2017</div></li>
+        </ul>
+      </section>
+
+      <!-- Courses -->
+      <section id='courses' class='cv-section'>
+        <h2>Courses</h2>
+        <ul class='timeline'>
+          <li>
+            <div class='title'>Deutsch Online Training — A2</div>
+            <div class='meta'>Jul 2024 – Oct 2024 · <a href="static/pdf/certificates/deutsch_A2_certificate.pdf" target="_blank">Certificate of completion</a></div>
+          </li>
+          <li>
+            <div class='title'>Deutsch Online Training — B1</div>
+            <div class='meta'>Sep 2024 – Dec 2024 · <a href="static/pdf/certificates/deutsch_B1_certificate.pdf" target="_blank">Certificate of completion</a></div>
+          </li>
         </ul>
       </section>
 


### PR DESCRIPTION
## Summary
- Relocate Courses section to end of profile page after Certificates
- Display A2 and B1 course durations and certificate preview links without downloadable titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab27b75934832db3ce0ef0de1f2901