### PR TITLE
Add localized Home links to Röstigraben pages

### DIFF
--- a/roestigraben.html
+++ b/roestigraben.html
@@ -18,6 +18,7 @@
     <a href="roestigraben_it.html" class="lang-btn">IT</a>
     <span class="lang-btn active">EN</span>
   </div>
+  <a href="index.html" class="home-link">Home</a>
   <a href="index.html" class="swiss-cross" aria-label="Back to homepage"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">

--- a/roestigraben.html
+++ b/roestigraben.html
@@ -12,13 +12,20 @@
   <link rel="stylesheet" href="static/css/roestigraben.css">
 </head>
 <body>
-  <div class="language-switcher">
-    <a href="roestigraben_de.html" class="lang-btn">DE</a>
-    <a href="roestigraben_fr.html" class="lang-btn">FR</a>
-    <a href="roestigraben_it.html" class="lang-btn">IT</a>
-    <span class="lang-btn active">EN</span>
+  <div class="nav-container">
+    <a href="index.html" class="home-icon" aria-label="Home">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 12L12 3l9 9"></path>
+        <path d="M5 10v11h14V10"></path>
+      </svg>
+    </a>
+    <div class="language-switcher">
+      <a href="roestigraben_de.html" class="lang-btn">DE</a>
+      <a href="roestigraben_fr.html" class="lang-btn">FR</a>
+      <a href="roestigraben_it.html" class="lang-btn">IT</a>
+      <span class="lang-btn active">EN</span>
+    </div>
   </div>
-  <a href="index.html" class="home-link">Home</a>
   <a href="index.html" class="swiss-cross" aria-label="Back to homepage"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">

--- a/roestigraben.html
+++ b/roestigraben.html
@@ -14,9 +14,8 @@
 <body>
   <div class="nav-container">
     <a href="index.html" class="home-icon" aria-label="Home">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M3 12L12 3l9 9"></path>
-        <path d="M5 10v11h14V10"></path>
+      <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"></path>
       </svg>
     </a>
     <div class="language-switcher">

--- a/roestigraben_de.html
+++ b/roestigraben_de.html
@@ -14,9 +14,8 @@
 <body>
   <div class="nav-container">
     <a href="index.html" class="home-icon" aria-label="Startseite">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M3 12L12 3l9 9"></path>
-        <path d="M5 10v11h14V10"></path>
+      <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"></path>
       </svg>
     </a>
     <div class="language-switcher">

--- a/roestigraben_de.html
+++ b/roestigraben_de.html
@@ -18,6 +18,7 @@
     <a href="roestigraben_it.html" class="lang-btn">IT</a>
     <a href="roestigraben.html" class="lang-btn">EN</a>
   </div>
+  <a href="index.html" class="home-link">Startseite</a>
   <a href="index.html" class="swiss-cross" aria-label="Zur Startseite"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">

--- a/roestigraben_de.html
+++ b/roestigraben_de.html
@@ -12,13 +12,20 @@
   <link rel="stylesheet" href="static/css/roestigraben.css">
 </head>
 <body>
-  <div class="language-switcher">
-    <span class="lang-btn active">DE</span>
-    <a href="roestigraben_fr.html" class="lang-btn">FR</a>
-    <a href="roestigraben_it.html" class="lang-btn">IT</a>
-    <a href="roestigraben.html" class="lang-btn">EN</a>
+  <div class="nav-container">
+    <a href="index.html" class="home-icon" aria-label="Startseite">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 12L12 3l9 9"></path>
+        <path d="M5 10v11h14V10"></path>
+      </svg>
+    </a>
+    <div class="language-switcher">
+      <span class="lang-btn active">DE</span>
+      <a href="roestigraben_fr.html" class="lang-btn">FR</a>
+      <a href="roestigraben_it.html" class="lang-btn">IT</a>
+      <a href="roestigraben.html" class="lang-btn">EN</a>
+    </div>
   </div>
-  <a href="index.html" class="home-link">Startseite</a>
   <a href="index.html" class="swiss-cross" aria-label="Zur Startseite"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">

--- a/roestigraben_fr.html
+++ b/roestigraben_fr.html
@@ -14,9 +14,8 @@
 <body>
   <div class="nav-container">
     <a href="index.html" class="home-icon" aria-label="Accueil">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M3 12L12 3l9 9"></path>
-        <path d="M5 10v11h14V10"></path>
+      <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"></path>
       </svg>
     </a>
     <div class="language-switcher">

--- a/roestigraben_fr.html
+++ b/roestigraben_fr.html
@@ -18,6 +18,7 @@
     <a href="roestigraben_it.html" class="lang-btn">IT</a>
     <a href="roestigraben.html" class="lang-btn">EN</a>
   </div>
+  <a href="index.html" class="home-link">Accueil</a>
   <a href="index.html" class="swiss-cross" aria-label="Retour à l'accueil"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">

--- a/roestigraben_fr.html
+++ b/roestigraben_fr.html
@@ -12,13 +12,20 @@
   <link rel="stylesheet" href="static/css/roestigraben.css">
 </head>
 <body>
-  <div class="language-switcher">
-    <a href="roestigraben_de.html" class="lang-btn">DE</a>
-    <span class="lang-btn active">FR</span>
-    <a href="roestigraben_it.html" class="lang-btn">IT</a>
-    <a href="roestigraben.html" class="lang-btn">EN</a>
+  <div class="nav-container">
+    <a href="index.html" class="home-icon" aria-label="Accueil">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 12L12 3l9 9"></path>
+        <path d="M5 10v11h14V10"></path>
+      </svg>
+    </a>
+    <div class="language-switcher">
+      <a href="roestigraben_de.html" class="lang-btn">DE</a>
+      <span class="lang-btn active">FR</span>
+      <a href="roestigraben_it.html" class="lang-btn">IT</a>
+      <a href="roestigraben.html" class="lang-btn">EN</a>
+    </div>
   </div>
-  <a href="index.html" class="home-link">Accueil</a>
   <a href="index.html" class="swiss-cross" aria-label="Retour à l'accueil"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">

--- a/roestigraben_it.html
+++ b/roestigraben_it.html
@@ -12,13 +12,20 @@
   <link rel="stylesheet" href="static/css/roestigraben.css">
 </head>
 <body>
-  <div class="language-switcher">
-    <a href="roestigraben_de.html" class="lang-btn">DE</a>
-    <a href="roestigraben_fr.html" class="lang-btn">FR</a>
-    <span class="lang-btn active">IT</span>
-    <a href="roestigraben.html" class="lang-btn">EN</a>
+  <div class="nav-container">
+    <a href="index.html" class="home-icon" aria-label="Home">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 12L12 3l9 9"></path>
+        <path d="M5 10v11h14V10"></path>
+      </svg>
+    </a>
+    <div class="language-switcher">
+      <a href="roestigraben_de.html" class="lang-btn">DE</a>
+      <a href="roestigraben_fr.html" class="lang-btn">FR</a>
+      <span class="lang-btn active">IT</span>
+      <a href="roestigraben.html" class="lang-btn">EN</a>
+    </div>
   </div>
-  <a href="index.html" class="home-link">Home</a>
   <a href="index.html" class="swiss-cross" aria-label="Torna alla home page"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">

--- a/roestigraben_it.html
+++ b/roestigraben_it.html
@@ -18,6 +18,7 @@
     <span class="lang-btn active">IT</span>
     <a href="roestigraben.html" class="lang-btn">EN</a>
   </div>
+  <a href="index.html" class="home-link">Home</a>
   <a href="index.html" class="swiss-cross" aria-label="Torna alla home page"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">

--- a/roestigraben_it.html
+++ b/roestigraben_it.html
@@ -14,9 +14,8 @@
 <body>
   <div class="nav-container">
     <a href="index.html" class="home-icon" aria-label="Home">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M3 12L12 3l9 9"></path>
-        <path d="M5 10v11h14V10"></path>
+      <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"></path>
       </svg>
     </a>
     <div class="language-switcher">

--- a/static/css/roestigraben.css
+++ b/static/css/roestigraben.css
@@ -18,7 +18,7 @@ body {
   left: 1rem;
   z-index: 10;
   display: flex;
-  gap: 0.25rem;
+  gap: 0.5rem;
 }
 
 /* Language switcher */
@@ -68,15 +68,21 @@ body {
   border-radius: 0.5rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   text-decoration: none;
-  color: #000;
   transition: background-color 0.3s;
+}
+.home-icon svg {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+.home-icon svg path {
+  fill: #fff;
+  transition: fill 0.3s;
 }
 .home-icon:hover {
   background-color: rgba(0, 0, 0, 0.1);
 }
-.home-icon svg {
-  width: 1.25rem;
-  height: 1.25rem;
+.home-icon:hover svg path {
+  fill: #808080;
 }
 /* Swiss cross in corner */
 .swiss-cross {

--- a/static/css/roestigraben.css
+++ b/static/css/roestigraben.css
@@ -26,7 +26,7 @@ body {
   position: relative;
   display: flex;
   gap: 0.25rem;
-  background: rgba(255, 255, 255, 0.85);
+  background: #fff;
   padding: 0.25rem;
   border-radius: 0.5rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
@@ -63,7 +63,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, 0.85);
+  background: #fff;
   padding: 0.25rem;
   border-radius: 0.5rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);

--- a/static/css/roestigraben.css
+++ b/static/css/roestigraben.css
@@ -75,7 +75,7 @@ body {
   height: 1.5rem;
 }
 .home-icon svg path {
-  fill: #fff;
+  fill: #000;
   transition: fill 0.3s;
 }
 .home-icon:hover {

--- a/static/css/roestigraben.css
+++ b/static/css/roestigraben.css
@@ -50,6 +50,24 @@ body {
   z-index: 0;
   transition: transform 0.3s ease, width 0.3s ease;
 }
+/* Home link next to Swiss cross */
+.home-link {
+  position: fixed;
+  top: 1rem;
+  right: 4rem;
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  text-decoration: none;
+  color: #000;
+  font-weight: 600;
+  transition: background-color 0.3s, color 0.3s;
+}
+.home-link:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+}
 /* Swiss cross in corner */
 .swiss-cross {
   position: fixed;

--- a/static/css/roestigraben.css
+++ b/static/css/roestigraben.css
@@ -11,12 +11,19 @@ body {
   overflow-x: hidden;
   position: relative;
 }
-/* Language switcher */
-.language-switcher {
+/* Navigation container */
+.nav-container {
   position: fixed;
   top: 1rem;
   left: 1rem;
   z-index: 10;
+  display: flex;
+  gap: 0.25rem;
+}
+
+/* Language switcher */
+.language-switcher {
+  position: relative;
   display: flex;
   gap: 0.25rem;
   background: rgba(255, 255, 255, 0.85);
@@ -50,23 +57,26 @@ body {
   z-index: 0;
   transition: transform 0.3s ease, width 0.3s ease;
 }
-/* Home link next to Swiss cross */
-.home-link {
-  position: fixed;
-  top: 1rem;
-  right: 4rem;
-  z-index: 10;
+
+/* Home icon */
+.home-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: rgba(255, 255, 255, 0.85);
-  padding: 0.25rem 0.5rem;
+  padding: 0.25rem;
   border-radius: 0.5rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   text-decoration: none;
   color: #000;
-  font-weight: 600;
-  transition: background-color 0.3s, color 0.3s;
+  transition: background-color 0.3s;
 }
-.home-link:hover {
+.home-icon:hover {
   background-color: rgba(0, 0, 0, 0.1);
+}
+.home-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
 }
 /* Swiss cross in corner */
 .swiss-cross {


### PR DESCRIPTION
## Summary
- Add small Home button linking to index on all Röstigraben language pages
- Style the Home button to sit beside the Swiss cross

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3ad43284832d81253412d8a4ac0e