### PR TITLE
Enable multi-procedure comparison on hospital pages

### DIFF
--- a/ch_hospital.html
+++ b/ch_hospital.html
@@ -21,7 +21,7 @@
   <a href="index.html" class="swiss-cross" aria-label="Back to homepage"></a>
 
   <section class="hero">
-    <h1>Case Volume Comparison of University Hospitals</h1>
+    <h1>Swiss Hospital Analysis (CH-IQI)</h1>
     <p class="tagline">
       The Swiss Inpatient Quality Indicators (CH-IQI) database offers insight into the
       performance of major hospitals. Select a procedure to explore 2023 case volumes.
@@ -30,13 +30,14 @@
       <span>Source: <a href="https://www.bag.admin.ch/en/quality-indicators-for-swiss-acute-hospitals" target="_blank" rel="noopener">FOPH CH-IQI</a></span>
       <span>Methodology: <a href="https://github.com/joonhaim/ch-iqi-analysis" target="_blank" rel="noopener">GitHub repo</a></span>
     </p>
+  </section>
+
+  <section class="comparison">
+    <h2>Case Volume Comparison of University Hospitals</h2>
     <p class="dataset-info">
       This dataset compiles case counts for Swiss university hospitals from the CH‑IQI indicators.
       I retrieved and reshaped the original tables using R scripts available in the linked repository.
     </p>
-  </section>
-
-  <section class="dashboard">
     <div class="chart-controls">
       <div class="chart-container">
         <canvas id="casesChart"></canvas>

--- a/ch_hospital.html
+++ b/ch_hospital.html
@@ -21,7 +21,7 @@
   <a href="index.html" class="swiss-cross" aria-label="Back to homepage"></a>
 
   <section class="hero">
-    <h1>Swiss Hospital Analysis (CH-IQI)</h1>
+    <h1>Case Volume Comparison of University Hospitals</h1>
     <p class="tagline">
       The Swiss Inpatient Quality Indicators (CH-IQI) database offers insight into the
       performance of major hospitals. Select a procedure to explore 2023 case volumes.
@@ -29,6 +29,10 @@
     <p class="hero-links">
       <span>Source: <a href="https://www.bag.admin.ch/en/quality-indicators-for-swiss-acute-hospitals" target="_blank" rel="noopener">FOPH CH-IQI</a></span>
       <span>Methodology: <a href="https://github.com/joonhaim/ch-iqi-analysis" target="_blank" rel="noopener">GitHub repo</a></span>
+    </p>
+    <p class="dataset-info">
+      This dataset compiles case counts for Swiss university hospitals from the CH‑IQI indicators.
+      I retrieved and reshaped the original tables using R scripts available in the linked repository.
     </p>
   </section>
 
@@ -39,16 +43,41 @@
       </div>
       <div class="controls">
         <p>Choose procedure:</p>
-        <div id="procedure-buttons" class="procedure-buttons">
-          <button class="procedure-btn active" data-code="A.3.1.F">Coronary catheterization</button>
-          <button class="procedure-btn" data-code="A.4.1.F">Cardiac rhythm disorders</button>
-          <button class="procedure-btn" data-code="A.5.1.F">Pacemaker/ICD implantation</button>
-          <button class="procedure-btn" data-code="B.2.3.F">Stroke unit – complex treatment</button>
-          <button class="procedure-btn" data-code="G.4.1.F">Breast cancer treatments</button>
+        <div id="procedure-groups">
+          <div class="procedure-group">
+            <p class="group-title">Cardiology</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn active" data-code="A.3.1.F">Coronary catheterization</button>
+              <button class="procedure-btn" data-code="A.4.1.F">Cardiac rhythm disorders</button>
+              <button class="procedure-btn" data-code="A.5.1.F">Pacemaker/ICD implantation</button>
+            </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Neurology</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="B.2.3.F">Stroke unit – complex treatment</button>
+            </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Oncology</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="G.4.1.F">Breast cancer treatments</button>
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div id="procedure-description" class="procedure-description"></div>
+  </section>
+
+  <section class="placeholder">
+    <h2>Hospital Performance Comparison</h2>
+    <p>Under construction</p>
+  </section>
+
+  <section class="placeholder">
+    <h2>Comparison of Large, Medium and Small Hospitals</h2>
+    <p>Under construction</p>
   </section>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/ch_hospital.html
+++ b/ch_hospital.html
@@ -33,18 +33,20 @@
   </section>
 
   <section class="dashboard">
-    <div class="controls">
-      <p>Choose procedure:</p>
-      <div id="procedure-buttons" class="procedure-buttons">
-        <button class="procedure-btn active" data-code="A.3.1.F">Coronary catheterization</button>
-        <button class="procedure-btn" data-code="A.4.1.F">Cardiac rhythm disorders</button>
-        <button class="procedure-btn" data-code="A.5.1.F">Pacemaker/ICD implantation</button>
-        <button class="procedure-btn" data-code="B.2.3.F">Stroke unit – complex treatment</button>
-        <button class="procedure-btn" data-code="G.4.1.F">Breast cancer treatments</button>
+    <div class="chart-controls">
+      <div class="chart-container">
+        <canvas id="casesChart"></canvas>
       </div>
-    </div>
-    <div class="chart-container">
-      <canvas id="casesChart"></canvas>
+      <div class="controls">
+        <p>Choose procedure:</p>
+        <div id="procedure-buttons" class="procedure-buttons">
+          <button class="procedure-btn active" data-code="A.3.1.F">Coronary catheterization</button>
+          <button class="procedure-btn" data-code="A.4.1.F">Cardiac rhythm disorders</button>
+          <button class="procedure-btn" data-code="A.5.1.F">Pacemaker/ICD implantation</button>
+          <button class="procedure-btn" data-code="B.2.3.F">Stroke unit – complex treatment</button>
+          <button class="procedure-btn" data-code="G.4.1.F">Breast cancer treatments</button>
+        </div>
+      </div>
     </div>
     <div id="procedure-description" class="procedure-description"></div>
   </section>

--- a/ch_hospital_de.html
+++ b/ch_hospital_de.html
@@ -32,18 +32,20 @@
   </section>
 
   <section class="dashboard">
-    <div class="controls">
-      <p>Verfahren auswählen:</p>
-      <div id="procedure-buttons" class="procedure-buttons">
-        <button class="procedure-btn active" data-code="A.3.1.F">Koronarangiographie</button>
-        <button class="procedure-btn" data-code="A.4.1.F">Herzrhythmusstörungen</button>
-        <button class="procedure-btn" data-code="A.5.1.F">Schrittmacher/ICD-Implantation</button>
-        <button class="procedure-btn" data-code="B.2.3.F">Schlaganfallstation – komplex</button>
-        <button class="procedure-btn" data-code="G.4.1.F">Brustkrebs-Behandlungen</button>
+    <div class="chart-controls">
+      <div class="chart-container">
+        <canvas id="casesChart"></canvas>
       </div>
-    </div>
-    <div class="chart-container">
-      <canvas id="casesChart"></canvas>
+      <div class="controls">
+        <p>Verfahren auswählen:</p>
+        <div id="procedure-buttons" class="procedure-buttons">
+          <button class="procedure-btn active" data-code="A.3.1.F">Koronarangiographie</button>
+          <button class="procedure-btn" data-code="A.4.1.F">Herzrhythmusstörungen</button>
+          <button class="procedure-btn" data-code="A.5.1.F">Schrittmacher/ICD-Implantation</button>
+          <button class="procedure-btn" data-code="B.2.3.F">Schlaganfallstation – komplex</button>
+          <button class="procedure-btn" data-code="G.4.1.F">Brustkrebs-Behandlungen</button>
+        </div>
+      </div>
     </div>
     <div id="procedure-description" class="procedure-description"></div>
   </section>

--- a/ch_hospital_de.html
+++ b/ch_hospital_de.html
@@ -21,13 +21,17 @@
   <a href="index.html" class="swiss-cross" aria-label="Zur Startseite"></a>
 
   <section class="hero">
-    <h1>Schweizer Spitalanalyse (CH-IQI)</h1>
+    <h1>Fallzahlvergleich der Universitätsspitäler</h1>
     <p class="tagline">
       Die Datenbank der Schweizer Qualitätsindikatoren (CH-IQI) bietet Einblick in die Leistung der grossen Universitätsspitäler. Wählen Sie ein Verfahren, um die Fallzahlen 2023 zu erkunden.
     </p>
     <p class="hero-links">
       <span>Quelle: <a href="https://www.bag.admin.ch/de/qualitaetsindikatoren-der-schweizer-akutspitaeler" target="_blank" rel="noopener">BAG CH-IQI</a></span>
       <span>Methodik: <a href="https://github.com/joonhaim/ch-iqi-analysis" target="_blank" rel="noopener">GitHub-Repo</a></span>
+    </p>
+    <p class="dataset-info">
+      Dieser Datensatz enthält Fallzahlen der Schweizer Universitätsspitäler aus den CH‑IQI-Indikatoren.
+      Die ursprünglichen Tabellen habe ich mit R-Skripten aus dem verlinkten Repository abgerufen und aufbereitet.
     </p>
   </section>
 
@@ -38,16 +42,41 @@
       </div>
       <div class="controls">
         <p>Verfahren auswählen:</p>
-        <div id="procedure-buttons" class="procedure-buttons">
-          <button class="procedure-btn active" data-code="A.3.1.F">Koronarangiographie</button>
-          <button class="procedure-btn" data-code="A.4.1.F">Herzrhythmusstörungen</button>
-          <button class="procedure-btn" data-code="A.5.1.F">Schrittmacher/ICD-Implantation</button>
-          <button class="procedure-btn" data-code="B.2.3.F">Schlaganfallstation – komplex</button>
-          <button class="procedure-btn" data-code="G.4.1.F">Brustkrebs-Behandlungen</button>
+        <div id="procedure-groups">
+          <div class="procedure-group">
+            <p class="group-title">Kardiologie</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn active" data-code="A.3.1.F">Koronarangiographie</button>
+              <button class="procedure-btn" data-code="A.4.1.F">Herzrhythmusstörungen</button>
+              <button class="procedure-btn" data-code="A.5.1.F">Schrittmacher/ICD-Implantation</button>
+            </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Neurologie</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="B.2.3.F">Schlaganfallstation – komplex</button>
+            </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Onkologie</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="G.4.1.F">Brustkrebs-Behandlungen</button>
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div id="procedure-description" class="procedure-description"></div>
+  </section>
+
+  <section class="placeholder">
+    <h2>Vergleich der Krankenhausleistung</h2>
+    <p>Im Aufbau</p>
+  </section>
+
+  <section class="placeholder">
+    <h2>Vergleich großer, mittlerer und kleiner Spitäler</h2>
+    <p>Im Aufbau</p>
   </section>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/ch_hospital_de.html
+++ b/ch_hospital_de.html
@@ -21,7 +21,7 @@
   <a href="index.html" class="swiss-cross" aria-label="Zur Startseite"></a>
 
   <section class="hero">
-    <h1>Fallzahlvergleich der Universitätsspitäler</h1>
+    <h1>Schweizer Spitalanalyse (CH-IQI)</h1>
     <p class="tagline">
       Die Datenbank der Schweizer Qualitätsindikatoren (CH-IQI) bietet Einblick in die Leistung der grossen Universitätsspitäler. Wählen Sie ein Verfahren, um die Fallzahlen 2023 zu erkunden.
     </p>
@@ -29,13 +29,14 @@
       <span>Quelle: <a href="https://www.bag.admin.ch/de/qualitaetsindikatoren-der-schweizer-akutspitaeler" target="_blank" rel="noopener">BAG CH-IQI</a></span>
       <span>Methodik: <a href="https://github.com/joonhaim/ch-iqi-analysis" target="_blank" rel="noopener">GitHub-Repo</a></span>
     </p>
+  </section>
+
+  <section class="comparison">
+    <h2>Fallzahlvergleich der Universitätsspitäler</h2>
     <p class="dataset-info">
       Dieser Datensatz enthält Fallzahlen der Schweizer Universitätsspitäler aus den CH‑IQI-Indikatoren.
       Die ursprünglichen Tabellen habe ich mit R-Skripten aus dem verlinkten Repository abgerufen und aufbereitet.
     </p>
-  </section>
-
-  <section class="dashboard">
     <div class="chart-controls">
       <div class="chart-container">
         <canvas id="casesChart"></canvas>

--- a/ch_hospital_fr.html
+++ b/ch_hospital_fr.html
@@ -21,13 +21,17 @@
   <a href="index.html" class="swiss-cross" aria-label="Retour à l'accueil"></a>
 
   <section class="hero">
-    <h1>Analyse des hôpitaux suisses (CH-IQI)</h1>
+    <h1>Comparaison du volume des cas des hôpitaux universitaires</h1>
     <p class="tagline">
       La base de données des Indicateurs de qualité hospitaliers (CH-IQI) offre un aperçu des performances des principaux hôpitaux universitaires. Sélectionnez une intervention pour explorer les volumes de cas 2023.
     </p>
     <p class="hero-links">
       <span>Source : <a href="https://www.bag.admin.ch/fr/indicateurs-de-qualite-des-hopitaux-suisses-de-soins-aigus" target="_blank" rel="noopener">OFSP CH-IQI</a></span>
       <span>Méthodologie : <a href="https://github.com/joonhaim/ch-iqi-analysis" target="_blank" rel="noopener">repo GitHub</a></span>
+    </p>
+    <p class="dataset-info">
+      Cet ensemble de données réunit les nombres de cas des hôpitaux universitaires suisses à partir des indicateurs CH‑IQI.
+      J'ai extrait et restructuré les tableaux originaux à l'aide de scripts R disponibles dans le dépôt lié.
     </p>
   </section>
 
@@ -38,17 +42,42 @@
         </div>
         <div class="controls">
           <p>Choisir une intervention :</p>
-          <div id="procedure-buttons" class="procedure-buttons">
-            <button class="procedure-btn active" data-code="A.3.1.F">Cathétérisme coronarien</button>
-            <button class="procedure-btn" data-code="A.4.1.F">Troubles du rythme cardiaque</button>
-            <button class="procedure-btn" data-code="A.5.1.F">Implantation de pacemaker/DIC</button>
-            <button class="procedure-btn" data-code="B.2.3.F">Unité AVC – traitement complexe</button>
-            <button class="procedure-btn" data-code="G.4.1.F">Traitements du cancer du sein</button>
+          <div id="procedure-groups">
+            <div class="procedure-group">
+              <p class="group-title">Cardiologie</p>
+              <div class="procedure-buttons">
+                <button class="procedure-btn active" data-code="A.3.1.F">Cathétérisme coronarien</button>
+                <button class="procedure-btn" data-code="A.4.1.F">Troubles du rythme cardiaque</button>
+                <button class="procedure-btn" data-code="A.5.1.F">Implantation de pacemaker/DIC</button>
+              </div>
+            </div>
+            <div class="procedure-group">
+              <p class="group-title">Neurologie</p>
+              <div class="procedure-buttons">
+                <button class="procedure-btn" data-code="B.2.3.F">Unité AVC – traitement complexe</button>
+              </div>
+            </div>
+            <div class="procedure-group">
+              <p class="group-title">Oncologie</p>
+              <div class="procedure-buttons">
+                <button class="procedure-btn" data-code="G.4.1.F">Traitements du cancer du sein</button>
+              </div>
+            </div>
           </div>
         </div>
       </div>
       <div id="procedure-description" class="procedure-description"></div>
     </section>
+
+  <section class="placeholder">
+    <h2>Comparaison des performances des hôpitaux</h2>
+    <p>En construction</p>
+  </section>
+
+  <section class="placeholder">
+    <h2>Comparaison des grands, moyens et petits hôpitaux</h2>
+    <p>En construction</p>
+  </section>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="static/js/ch_hospital.js"></script>

--- a/ch_hospital_fr.html
+++ b/ch_hospital_fr.html
@@ -31,22 +31,24 @@
     </p>
   </section>
 
-  <section class="dashboard">
-    <div class="controls">
-      <p>Choisir une intervention :</p>
-      <div id="procedure-buttons" class="procedure-buttons">
-        <button class="procedure-btn active" data-code="A.3.1.F">Cathétérisme coronarien</button>
-        <button class="procedure-btn" data-code="A.4.1.F">Troubles du rythme cardiaque</button>
-        <button class="procedure-btn" data-code="A.5.1.F">Implantation de pacemaker/DIC</button>
-        <button class="procedure-btn" data-code="B.2.3.F">Unité AVC – traitement complexe</button>
-        <button class="procedure-btn" data-code="G.4.1.F">Traitements du cancer du sein</button>
+    <section class="dashboard">
+      <div class="chart-controls">
+        <div class="chart-container">
+          <canvas id="casesChart"></canvas>
+        </div>
+        <div class="controls">
+          <p>Choisir une intervention :</p>
+          <div id="procedure-buttons" class="procedure-buttons">
+            <button class="procedure-btn active" data-code="A.3.1.F">Cathétérisme coronarien</button>
+            <button class="procedure-btn" data-code="A.4.1.F">Troubles du rythme cardiaque</button>
+            <button class="procedure-btn" data-code="A.5.1.F">Implantation de pacemaker/DIC</button>
+            <button class="procedure-btn" data-code="B.2.3.F">Unité AVC – traitement complexe</button>
+            <button class="procedure-btn" data-code="G.4.1.F">Traitements du cancer du sein</button>
+          </div>
+        </div>
       </div>
-    </div>
-    <div class="chart-container">
-      <canvas id="casesChart"></canvas>
-    </div>
-    <div id="procedure-description" class="procedure-description"></div>
-  </section>
+      <div id="procedure-description" class="procedure-description"></div>
+    </section>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="static/js/ch_hospital.js"></script>

--- a/ch_hospital_fr.html
+++ b/ch_hospital_fr.html
@@ -21,7 +21,7 @@
   <a href="index.html" class="swiss-cross" aria-label="Retour à l'accueil"></a>
 
   <section class="hero">
-    <h1>Comparaison du volume des cas des hôpitaux universitaires</h1>
+    <h1>Analyse des hôpitaux suisses (CH-IQI)</h1>
     <p class="tagline">
       La base de données des Indicateurs de qualité hospitaliers (CH-IQI) offre un aperçu des performances des principaux hôpitaux universitaires. Sélectionnez une intervention pour explorer les volumes de cas 2023.
     </p>
@@ -29,45 +29,46 @@
       <span>Source : <a href="https://www.bag.admin.ch/fr/indicateurs-de-qualite-des-hopitaux-suisses-de-soins-aigus" target="_blank" rel="noopener">OFSP CH-IQI</a></span>
       <span>Méthodologie : <a href="https://github.com/joonhaim/ch-iqi-analysis" target="_blank" rel="noopener">repo GitHub</a></span>
     </p>
+  </section>
+
+  <section class="comparison">
+    <h2>Comparaison du volume des cas des hôpitaux universitaires</h2>
     <p class="dataset-info">
       Cet ensemble de données réunit les nombres de cas des hôpitaux universitaires suisses à partir des indicateurs CH‑IQI.
       J'ai extrait et restructuré les tableaux originaux à l'aide de scripts R disponibles dans le dépôt lié.
     </p>
-  </section>
-
-    <section class="dashboard">
-      <div class="chart-controls">
-        <div class="chart-container">
-          <canvas id="casesChart"></canvas>
-        </div>
-        <div class="controls">
-          <p>Choisir une intervention :</p>
-          <div id="procedure-groups">
-            <div class="procedure-group">
-              <p class="group-title">Cardiologie</p>
-              <div class="procedure-buttons">
-                <button class="procedure-btn active" data-code="A.3.1.F">Cathétérisme coronarien</button>
-                <button class="procedure-btn" data-code="A.4.1.F">Troubles du rythme cardiaque</button>
-                <button class="procedure-btn" data-code="A.5.1.F">Implantation de pacemaker/DIC</button>
-              </div>
+    <div class="chart-controls">
+      <div class="chart-container">
+        <canvas id="casesChart"></canvas>
+      </div>
+      <div class="controls">
+        <p>Choisir une intervention :</p>
+        <div id="procedure-groups">
+          <div class="procedure-group">
+            <p class="group-title">Cardiologie</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn active" data-code="A.3.1.F">Cathétérisme coronarien</button>
+              <button class="procedure-btn" data-code="A.4.1.F">Troubles du rythme cardiaque</button>
+              <button class="procedure-btn" data-code="A.5.1.F">Implantation de pacemaker/DIC</button>
             </div>
-            <div class="procedure-group">
-              <p class="group-title">Neurologie</p>
-              <div class="procedure-buttons">
-                <button class="procedure-btn" data-code="B.2.3.F">Unité AVC – traitement complexe</button>
-              </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Neurologie</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="B.2.3.F">Unité AVC – traitement complexe</button>
             </div>
-            <div class="procedure-group">
-              <p class="group-title">Oncologie</p>
-              <div class="procedure-buttons">
-                <button class="procedure-btn" data-code="G.4.1.F">Traitements du cancer du sein</button>
-              </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Oncologie</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="G.4.1.F">Traitements du cancer du sein</button>
             </div>
           </div>
         </div>
       </div>
-      <div id="procedure-description" class="procedure-description"></div>
-    </section>
+    </div>
+    <div id="procedure-description" class="procedure-description"></div>
+  </section>
 
   <section class="placeholder">
     <h2>Comparaison des performances des hôpitaux</h2>

--- a/ch_hospital_it.html
+++ b/ch_hospital_it.html
@@ -21,7 +21,7 @@
   <a href="index.html" class="swiss-cross" aria-label="Torna alla homepage"></a>
 
   <section class="hero">
-    <h1>Confronto del volume dei casi degli ospedali universitari</h1>
+    <h1>Analisi degli ospedali svizzeri (CH-IQI)</h1>
     <p class="tagline">
       Il database degli Indicatori di qualità ospedaliera (CH-IQI) offre una panoramica delle prestazioni dei principali ospedali universitari. Seleziona una procedura per esplorare i volumi di casi 2023.
     </p>
@@ -29,45 +29,46 @@
       <span>Fonte: <a href="https://www.bag.admin.ch/it/indicatori-di-qualita-degli-ospedali-per-cure-acute-svizzeri" target="_blank" rel="noopener">UFSP CH-IQI</a></span>
       <span>Metodologia: <a href="https://github.com/joonhaim/ch-iqi-analysis" target="_blank" rel="noopener">repository GitHub</a></span>
     </p>
+  </section>
+
+  <section class="comparison">
+    <h2>Confronto del volume dei casi degli ospedali universitari</h2>
     <p class="dataset-info">
       Questo set di dati raccoglie il numero di casi degli ospedali universitari svizzeri dagli indicatori CH‑IQI.
       Ho estratto e rielaborato le tabelle originali con script R disponibili nel repository collegato.
     </p>
-  </section>
-
-    <section class="dashboard">
-      <div class="chart-controls">
-        <div class="chart-container">
-          <canvas id="casesChart"></canvas>
-        </div>
-        <div class="controls">
-          <p>Scegli la procedura:</p>
-          <div id="procedure-groups">
-            <div class="procedure-group">
-              <p class="group-title">Cardiologia</p>
-              <div class="procedure-buttons">
-                <button class="procedure-btn active" data-code="A.3.1.F">Cateterismo coronarico</button>
-                <button class="procedure-btn" data-code="A.4.1.F">Disturbi del ritmo cardiaco</button>
-                <button class="procedure-btn" data-code="A.5.1.F">Impianto di pacemaker/ICD</button>
-              </div>
+    <div class="chart-controls">
+      <div class="chart-container">
+        <canvas id="casesChart"></canvas>
+      </div>
+      <div class="controls">
+        <p>Scegli la procedura:</p>
+        <div id="procedure-groups">
+          <div class="procedure-group">
+            <p class="group-title">Cardiologia</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn active" data-code="A.3.1.F">Cateterismo coronarico</button>
+              <button class="procedure-btn" data-code="A.4.1.F">Disturbi del ritmo cardiaco</button>
+              <button class="procedure-btn" data-code="A.5.1.F">Impianto di pacemaker/ICD</button>
             </div>
-            <div class="procedure-group">
-              <p class="group-title">Neurologia</p>
-              <div class="procedure-buttons">
-                <button class="procedure-btn" data-code="B.2.3.F">Unità ictus – trattamento complesso</button>
-              </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Neurologia</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="B.2.3.F">Unità ictus – trattamento complesso</button>
             </div>
-            <div class="procedure-group">
-              <p class="group-title">Oncologia</p>
-              <div class="procedure-buttons">
-                <button class="procedure-btn" data-code="G.4.1.F">Trattamenti per il cancro al seno</button>
-              </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Oncologia</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="G.4.1.F">Trattamenti per il cancro al seno</button>
             </div>
           </div>
         </div>
       </div>
-      <div id="procedure-description" class="procedure-description"></div>
-    </section>
+    </div>
+    <div id="procedure-description" class="procedure-description"></div>
+  </section>
 
   <section class="placeholder">
     <h2>Confronto delle prestazioni degli ospedali</h2>

--- a/ch_hospital_it.html
+++ b/ch_hospital_it.html
@@ -31,22 +31,24 @@
     </p>
   </section>
 
-  <section class="dashboard">
-    <div class="controls">
-      <p>Scegli la procedura:</p>
-      <div id="procedure-buttons" class="procedure-buttons">
-        <button class="procedure-btn active" data-code="A.3.1.F">Cateterismo coronarico</button>
-        <button class="procedure-btn" data-code="A.4.1.F">Disturbi del ritmo cardiaco</button>
-        <button class="procedure-btn" data-code="A.5.1.F">Impianto di pacemaker/ICD</button>
-        <button class="procedure-btn" data-code="B.2.3.F">Unità ictus – trattamento complesso</button>
-        <button class="procedure-btn" data-code="G.4.1.F">Trattamenti per il cancro al seno</button>
+    <section class="dashboard">
+      <div class="chart-controls">
+        <div class="chart-container">
+          <canvas id="casesChart"></canvas>
+        </div>
+        <div class="controls">
+          <p>Scegli la procedura:</p>
+          <div id="procedure-buttons" class="procedure-buttons">
+            <button class="procedure-btn active" data-code="A.3.1.F">Cateterismo coronarico</button>
+            <button class="procedure-btn" data-code="A.4.1.F">Disturbi del ritmo cardiaco</button>
+            <button class="procedure-btn" data-code="A.5.1.F">Impianto di pacemaker/ICD</button>
+            <button class="procedure-btn" data-code="B.2.3.F">Unità ictus – trattamento complesso</button>
+            <button class="procedure-btn" data-code="G.4.1.F">Trattamenti per il cancro al seno</button>
+          </div>
+        </div>
       </div>
-    </div>
-    <div class="chart-container">
-      <canvas id="casesChart"></canvas>
-    </div>
-    <div id="procedure-description" class="procedure-description"></div>
-  </section>
+      <div id="procedure-description" class="procedure-description"></div>
+    </section>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="static/js/ch_hospital.js"></script>

--- a/ch_hospital_it.html
+++ b/ch_hospital_it.html
@@ -21,13 +21,17 @@
   <a href="index.html" class="swiss-cross" aria-label="Torna alla homepage"></a>
 
   <section class="hero">
-    <h1>Analisi degli ospedali svizzeri (CH-IQI)</h1>
+    <h1>Confronto del volume dei casi degli ospedali universitari</h1>
     <p class="tagline">
       Il database degli Indicatori di qualità ospedaliera (CH-IQI) offre una panoramica delle prestazioni dei principali ospedali universitari. Seleziona una procedura per esplorare i volumi di casi 2023.
     </p>
     <p class="hero-links">
       <span>Fonte: <a href="https://www.bag.admin.ch/it/indicatori-di-qualita-degli-ospedali-per-cure-acute-svizzeri" target="_blank" rel="noopener">UFSP CH-IQI</a></span>
       <span>Metodologia: <a href="https://github.com/joonhaim/ch-iqi-analysis" target="_blank" rel="noopener">repository GitHub</a></span>
+    </p>
+    <p class="dataset-info">
+      Questo set di dati raccoglie il numero di casi degli ospedali universitari svizzeri dagli indicatori CH‑IQI.
+      Ho estratto e rielaborato le tabelle originali con script R disponibili nel repository collegato.
     </p>
   </section>
 
@@ -38,17 +42,42 @@
         </div>
         <div class="controls">
           <p>Scegli la procedura:</p>
-          <div id="procedure-buttons" class="procedure-buttons">
-            <button class="procedure-btn active" data-code="A.3.1.F">Cateterismo coronarico</button>
-            <button class="procedure-btn" data-code="A.4.1.F">Disturbi del ritmo cardiaco</button>
-            <button class="procedure-btn" data-code="A.5.1.F">Impianto di pacemaker/ICD</button>
-            <button class="procedure-btn" data-code="B.2.3.F">Unità ictus – trattamento complesso</button>
-            <button class="procedure-btn" data-code="G.4.1.F">Trattamenti per il cancro al seno</button>
+          <div id="procedure-groups">
+            <div class="procedure-group">
+              <p class="group-title">Cardiologia</p>
+              <div class="procedure-buttons">
+                <button class="procedure-btn active" data-code="A.3.1.F">Cateterismo coronarico</button>
+                <button class="procedure-btn" data-code="A.4.1.F">Disturbi del ritmo cardiaco</button>
+                <button class="procedure-btn" data-code="A.5.1.F">Impianto di pacemaker/ICD</button>
+              </div>
+            </div>
+            <div class="procedure-group">
+              <p class="group-title">Neurologia</p>
+              <div class="procedure-buttons">
+                <button class="procedure-btn" data-code="B.2.3.F">Unità ictus – trattamento complesso</button>
+              </div>
+            </div>
+            <div class="procedure-group">
+              <p class="group-title">Oncologia</p>
+              <div class="procedure-buttons">
+                <button class="procedure-btn" data-code="G.4.1.F">Trattamenti per il cancro al seno</button>
+              </div>
+            </div>
           </div>
         </div>
       </div>
       <div id="procedure-description" class="procedure-description"></div>
     </section>
+
+  <section class="placeholder">
+    <h2>Confronto delle prestazioni degli ospedali</h2>
+    <p>In costruzione</p>
+  </section>
+
+  <section class="placeholder">
+    <h2>Confronto tra ospedali grandi, medi e piccoli</h2>
+    <p>In costruzione</p>
+  </section>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="static/js/ch_hospital.js"></script>

--- a/static/css/ch_hospital.css
+++ b/static/css/ch_hospital.css
@@ -90,33 +90,59 @@ body {
   margin: 2rem auto;
   padding: 2rem;
 }
-.controls {
-  text-align: center;
-  margin-bottom: 1rem;
-}
-.procedure-buttons {
+
+.chart-controls {
   display: flex;
-  flex-wrap: wrap;
+  align-items: flex-start;
   justify-content: center;
-  gap: 0.5rem;
-}
-.procedure-btn {
-  padding: 0.5rem 0.75rem;
-  border: 1px solid #ccc;
-  border-radius: 0.25rem;
-  background: #fff;
-  cursor: pointer;
-  font-size: 0.9rem;
-}
-.procedure-btn.active {
-  background: #DA291C;
-  color: #fff;
-  border-color: #DA291C;
+  gap: 2rem;
 }
 
 .chart-container {
+  flex: 1;
   max-width: 900px;
-  margin: 0 auto;
+}
+
+.controls {
+  text-align: left;
+}
+
+.procedure-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.procedure-btn {
+  padding: 0.5rem 1rem;
+  border: 2px solid #DA291C;
+  border-radius: 9999px;
+  background: #fff;
+  color: #DA291C;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.procedure-btn.active,
+.procedure-btn:hover {
+  background: #DA291C;
+  color: #fff;
+}
+
+@media (max-width: 768px) {
+  .chart-controls {
+    flex-direction: column;
+  }
+  .controls {
+    margin-top: 1rem;
+    text-align: center;
+  }
+  .procedure-buttons {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
 }
 #casesChart {
   width: 100%;

--- a/static/css/ch_hospital.css
+++ b/static/css/ch_hospital.css
@@ -85,23 +85,32 @@ body {
   text-decoration: underline;
 }
 
-.dataset-info {
-  margin-top: 1rem;
-  font-size: 0.9rem;
-  line-height: 1.4;
+.comparison {
+  max-width: 1200px;
+  margin: 2rem auto;
+  padding: 2rem;
 }
 
-.dashboard {
-  max-width: 1200px;
-  margin: 3rem auto;
-  padding: 3rem;
+.comparison h2 {
+  text-align: center;
+  font-size: 1.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.dataset-info {
+  max-width: 800px;
+  margin: 0.5rem auto 2rem;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  text-align: center;
 }
 
 .chart-controls {
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  gap: 3rem;
+  gap: 2rem;
+  flex-wrap: wrap;
 }
 
 .chart-container {
@@ -111,6 +120,7 @@ body {
 
 .controls {
   text-align: left;
+  min-width: 220px;
 }
 
 .procedure-buttons {

--- a/static/css/ch_hospital.css
+++ b/static/css/ch_hospital.css
@@ -85,17 +85,23 @@ body {
   text-decoration: underline;
 }
 
+.dataset-info {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
 .dashboard {
   max-width: 1200px;
-  margin: 2rem auto;
-  padding: 2rem;
+  margin: 3rem auto;
+  padding: 3rem;
 }
 
 .chart-controls {
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  gap: 2rem;
+  gap: 3rem;
 }
 
 .chart-container {
@@ -110,7 +116,16 @@ body {
 .procedure-buttons {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
+}
+
+.procedure-group {
+  margin-bottom: 2rem;
+}
+
+.group-title {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
 }
 
 .procedure-btn {
@@ -153,4 +168,10 @@ body {
   margin-top: 1rem;
   text-align: center;
   font-size: 1rem;
+}
+
+.placeholder {
+  text-align: center;
+  padding: 3rem 0;
+  font-style: italic;
 }

--- a/static/js/ch_hospital.js
+++ b/static/js/ch_hospital.js
@@ -59,11 +59,11 @@ const ctx = document.getElementById('casesChart').getContext('2d');
 let casesChart;
 
 const palette = [
-  ['rgba(218, 41, 28, 0.6)', 'rgba(218, 41, 28, 1)'],
-  ['rgba(0, 122, 51, 0.6)', 'rgba(0, 122, 51, 1)'],
-  ['rgba(0, 45, 149, 0.6)', 'rgba(0, 45, 149, 1)'],
-  ['rgba(255, 195, 0, 0.6)', 'rgba(255, 195, 0, 1)'],
-  ['rgba(128, 0, 128, 0.6)', 'rgba(128, 0, 128, 1)']
+  ['rgba(230, 57, 70, 0.7)', 'rgba(230, 57, 70, 1)'],
+  ['rgba(69, 123, 157, 0.7)', 'rgba(69, 123, 157, 1)'],
+  ['rgba(42, 157, 143, 0.7)', 'rgba(42, 157, 143, 1)'],
+  ['rgba(233, 196, 106, 0.7)', 'rgba(233, 196, 106, 1)'],
+  ['rgba(141, 59, 114, 0.7)', 'rgba(141, 59, 114, 1)']
 ];
 
 function updateChart(codes) {

--- a/static/js/ch_hospital.js
+++ b/static/js/ch_hospital.js
@@ -58,12 +58,29 @@ const yAxisLabel = {
 const ctx = document.getElementById('casesChart').getContext('2d');
 let casesChart;
 
-function updateChart(code) {
-  const values = cases[code];
-  const label = procedureLabels[code][lang];
-  const hospitalLabels = hospitals[lang];
+const palette = [
+  ['rgba(218, 41, 28, 0.6)', 'rgba(218, 41, 28, 1)'],
+  ['rgba(0, 122, 51, 0.6)', 'rgba(0, 122, 51, 1)'],
+  ['rgba(0, 45, 149, 0.6)', 'rgba(0, 45, 149, 1)'],
+  ['rgba(255, 195, 0, 0.6)', 'rgba(255, 195, 0, 1)'],
+  ['rgba(128, 0, 128, 0.6)', 'rgba(128, 0, 128, 1)']
+];
 
-  document.getElementById('procedure-description').textContent = `${code} – ${label}`;
+function updateChart(codes) {
+  const hospitalLabels = hospitals[lang];
+  const descriptionEl = document.getElementById('procedure-description');
+
+  const datasets = codes.map((code, idx) => ({
+    label: procedureLabels[code][lang],
+    data: cases[code],
+    backgroundColor: palette[idx % palette.length][0],
+    borderColor: palette[idx % palette.length][1],
+    borderWidth: 1
+  }));
+
+  descriptionEl.innerHTML = codes
+    .map(code => `${code} – ${procedureLabels[code][lang]}`)
+    .join('<br>');
 
   if (casesChart) {
     casesChart.destroy();
@@ -73,13 +90,7 @@ function updateChart(code) {
     type: 'bar',
     data: {
       labels: hospitalLabels,
-      datasets: [{
-        label,
-        data: values,
-        backgroundColor: 'rgba(218, 41, 28, 0.6)',
-        borderColor: 'rgba(218, 41, 28, 1)',
-        borderWidth: 1
-      }]
+      datasets
     },
     options: {
       responsive: true,
@@ -98,13 +109,22 @@ function updateChart(code) {
 }
 
 const buttons = document.querySelectorAll('.procedure-btn');
+const selectedCodes = new Set(
+  Array.from(document.querySelectorAll('.procedure-btn.active')).map(b => b.dataset.code)
+);
+
 buttons.forEach(btn => {
   btn.addEventListener('click', () => {
-    buttons.forEach(b => b.classList.remove('active'));
-    btn.classList.add('active');
-    updateChart(btn.dataset.code);
+    const code = btn.dataset.code;
+    if (selectedCodes.has(code)) {
+      selectedCodes.delete(code);
+      btn.classList.remove('active');
+    } else {
+      selectedCodes.add(code);
+      btn.classList.add('active');
+    }
+    updateChart(Array.from(selectedCodes));
   });
 });
 
-const firstCode = document.querySelector('.procedure-btn.active').dataset.code;
-updateChart(firstCode);
+updateChart(Array.from(selectedCodes));


### PR DESCRIPTION
## Summary
- Move procedure toggles to the right of the chart across all hospital pages
- Restyle buttons with rounded Swiss-inspired design
- Support selecting multiple procedures and display them as separate bars in the chart

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7350ec8e8832d881ccbd6d24531b8