### PR TITLE
Expand CH-IQI chart data and redesign procedure controls

### DIFF
--- a/ch_hospital.html
+++ b/ch_hospital.html
@@ -57,12 +57,27 @@
             <p class="group-title">Neurology</p>
             <div class="procedure-buttons">
               <button class="procedure-btn" data-code="B.2.3.F">Stroke unit – complex treatment</button>
+              <button class="procedure-btn" data-code="B.4.1.F">Epilepsy treatments</button>
             </div>
           </div>
           <div class="procedure-group">
             <p class="group-title">Oncology</p>
             <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="D.3.1.F">Lung cancer treatments</button>
+              <button class="procedure-btn" data-code="E.4.11.F">Colorectal cancer treatments</button>
               <button class="procedure-btn" data-code="G.4.1.F">Breast cancer treatments</button>
+            </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Transplantation</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="L.5.1.F">Kidney transplant</button>
+            </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Orthopedics</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="Z.4.37.F">Primary hip prosthesis</button>
             </div>
           </div>
         </div>

--- a/ch_hospital_de.html
+++ b/ch_hospital_de.html
@@ -56,12 +56,27 @@
             <p class="group-title">Neurologie</p>
             <div class="procedure-buttons">
               <button class="procedure-btn" data-code="B.2.3.F">Schlaganfallstation – komplex</button>
+              <button class="procedure-btn" data-code="B.4.1.F">Epilepsiebehandlungen</button>
             </div>
           </div>
           <div class="procedure-group">
             <p class="group-title">Onkologie</p>
             <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="D.3.1.F">Behandlungen bei Lungenkrebs</button>
+              <button class="procedure-btn" data-code="E.4.11.F">Behandlungen bei kolorektalem Karzinom</button>
               <button class="procedure-btn" data-code="G.4.1.F">Brustkrebs-Behandlungen</button>
+            </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Transplantation</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="L.5.1.F">Nierentransplantation</button>
+            </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Orthopädie</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="Z.4.37.F">Hüftprothese (primär)</button>
             </div>
           </div>
         </div>

--- a/ch_hospital_fr.html
+++ b/ch_hospital_fr.html
@@ -56,12 +56,27 @@
             <p class="group-title">Neurologie</p>
             <div class="procedure-buttons">
               <button class="procedure-btn" data-code="B.2.3.F">Unité AVC – traitement complexe</button>
+              <button class="procedure-btn" data-code="B.4.1.F">Traitements de l'épilepsie</button>
             </div>
           </div>
           <div class="procedure-group">
             <p class="group-title">Oncologie</p>
             <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="D.3.1.F">Traitements du cancer du poumon</button>
+              <button class="procedure-btn" data-code="E.4.11.F">Traitements du cancer colorectal</button>
               <button class="procedure-btn" data-code="G.4.1.F">Traitements du cancer du sein</button>
+            </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Transplantation</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="L.5.1.F">Transplantation rénale</button>
+            </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Orthopédie</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="Z.4.37.F">Prothèse totale de hanche</button>
             </div>
           </div>
         </div>

--- a/ch_hospital_it.html
+++ b/ch_hospital_it.html
@@ -56,12 +56,27 @@
             <p class="group-title">Neurologia</p>
             <div class="procedure-buttons">
               <button class="procedure-btn" data-code="B.2.3.F">Unità ictus – trattamento complesso</button>
+              <button class="procedure-btn" data-code="B.4.1.F">Trattamenti per epilessia</button>
             </div>
           </div>
           <div class="procedure-group">
             <p class="group-title">Oncologia</p>
             <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="D.3.1.F">Trattamenti per cancro ai polmoni</button>
+              <button class="procedure-btn" data-code="E.4.11.F">Trattamenti per cancro colorettale</button>
               <button class="procedure-btn" data-code="G.4.1.F">Trattamenti per il cancro al seno</button>
+            </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Trapianti</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="L.5.1.F">Trapianto di rene</button>
+            </div>
+          </div>
+          <div class="procedure-group">
+            <p class="group-title">Ortopedia</p>
+            <div class="procedure-buttons">
+              <button class="procedure-btn" data-code="Z.4.37.F">Protesi d'anca primaria</button>
             </div>
           </div>
         </div>

--- a/static/css/ch_hospital.css
+++ b/static/css/ch_hospital.css
@@ -123,19 +123,26 @@ body {
   min-width: 220px;
 }
 
+#procedure-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
+}
+
 .procedure-buttons {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.5rem;
 }
 
 .procedure-group {
-  margin-bottom: 2rem;
+  margin-bottom: 0;
 }
 
 .group-title {
   font-weight: 600;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
+  color: #555;
 }
 
 .procedure-btn {
@@ -163,10 +170,12 @@ body {
     margin-top: 1rem;
     text-align: center;
   }
+  #procedure-groups {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
   .procedure-buttons {
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
   }
 }
 #casesChart {

--- a/static/js/ch_hospital.js
+++ b/static/js/ch_hospital.js
@@ -12,7 +12,12 @@ const cases = {
   'A.4.1.F': [703, 615, 1974, 1539, 764],
   'A.5.1.F': [265, 264, 714, 540, 486],
   'B.2.3.F': [751, 958, 1907, 1206, 909],
-  'G.4.1.F': [341, 349, 278, 339, 199]
+  'B.4.1.F': [301, 296, 379, 526, 235],
+  'D.3.1.F': [460, 377, 298, 509, 417],
+  'E.4.11.F': [228, 295, 162, 158, 220],
+  'G.4.1.F': [341, 349, 278, 339, 199],
+  'L.5.1.F': [61, 46, 78, 71, 109],
+  'Z.4.37.F': [308, 531, 133, 284, 67]
 };
 
 const procedureLabels = {
@@ -40,11 +45,41 @@ const procedureLabels = {
     fr: 'Unité AVC – traitement complexe',
     it: 'Unità ictus – trattamento complesso'
   },
+  'B.4.1.F': {
+    en: 'Epilepsy (inpatient, age >19)',
+    de: 'Epilepsie (stationär, Alter >19)',
+    fr: 'Épilepsie (hospitalisations, âge >19)',
+    it: 'Epilessia (ricoveri, età >19)'
+  },
+  'D.3.1.F': {
+    en: 'Lung cancer (inpatient treatments)',
+    de: 'Lungenkrebs (stationäre Behandlungen)',
+    fr: 'Cancer du poumon (traitements stationnaires)',
+    it: 'Cancro ai polmoni (trattamenti ospedalieri)'
+  },
+  'E.4.11.F': {
+    en: 'Colorectal cancer (inpatient treatments)',
+    de: 'Kolorektales Karzinom (stationäre Behandlungen)',
+    fr: 'Cancer colorectal (traitements stationnaires)',
+    it: 'Cancro colorettale (trattamenti ospedalieri)'
+  },
   'G.4.1.F': {
     en: 'Breast cancer (inpatient treatments)',
     de: 'Brustkrebs (stationäre Behandlungen)',
     fr: 'Cancer du sein (traitements stationnaires)',
     it: 'Cancro al seno (trattamenti ospedalieri)'
+  },
+  'L.5.1.F': {
+    en: 'Kidney transplant',
+    de: 'Nierentransplantation',
+    fr: 'Transplantation rénale',
+    it: 'Trapianto di rene'
+  },
+  'Z.4.37.F': {
+    en: 'Primary hip prosthesis',
+    de: 'Erstprothese Hüfte',
+    fr: 'Prothèse totale de hanche',
+    it: "Protesi d'anca primaria"
   }
 };
 
@@ -59,11 +94,16 @@ const ctx = document.getElementById('casesChart').getContext('2d');
 let casesChart;
 
 const palette = [
-  ['rgba(230, 57, 70, 0.7)', 'rgba(230, 57, 70, 1)'],
+  ['rgba(218, 41, 28, 0.7)', 'rgba(218, 41, 28, 1)'],
+  ['rgba(0, 0, 0, 0.7)', 'rgba(0, 0, 0, 1)'],
+  ['rgba(128, 128, 128, 0.7)', 'rgba(128, 128, 128, 1)'],
   ['rgba(69, 123, 157, 0.7)', 'rgba(69, 123, 157, 1)'],
   ['rgba(42, 157, 143, 0.7)', 'rgba(42, 157, 143, 1)'],
   ['rgba(233, 196, 106, 0.7)', 'rgba(233, 196, 106, 1)'],
-  ['rgba(141, 59, 114, 0.7)', 'rgba(141, 59, 114, 1)']
+  ['rgba(141, 59, 114, 0.7)', 'rgba(141, 59, 114, 1)'],
+  ['rgba(90, 90, 90, 0.7)', 'rgba(90, 90, 90, 1)'],
+  ['rgba(200, 200, 200, 0.7)', 'rgba(200, 200, 200, 1)'],
+  ['rgba(120, 0, 0, 0.7)', 'rgba(120, 0, 0, 1)']
 ];
 
 function updateChart(codes) {
@@ -71,7 +111,7 @@ function updateChart(codes) {
   const descriptionEl = document.getElementById('procedure-description');
 
   const datasets = codes.map((code, idx) => ({
-    label: procedureLabels[code][lang],
+    label: code,
     data: cases[code],
     backgroundColor: palette[idx % palette.length][0],
     borderColor: palette[idx % palette.length][1],


### PR DESCRIPTION
## Summary
- Extend procedure dataset to include 10 CH-IQI indicators and display codes in chart legend
- Add translation strings and buttons for epilepsy, cancer, transplant and orthopedic procedures across all languages
- Refactor procedure selector into grid layout for cleaner Swiss minimalist UX

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c73a3d64d0832d810f2af50f768378