### PR TITLE
Clean up hospital dataset text and improve chart legend

### DIFF
--- a/ch_hospital.html
+++ b/ch_hospital.html
@@ -38,10 +38,8 @@
       This dataset compiles case counts for Swiss university hospitals from the CH‑IQI indicators.
       I retrieved and reshaped the original tables using R scripts available in the linked repository.
     </p>
-    <p class="dataset-details fade-element">
-      The quality indicators for Swiss acute care hospitals contain data on treatments carried out since 2008. They show case numbers, various percentages (e.g., Caesarean rate), mortality rates for certain pathologies and interventions as well as selected lengths of stay, transfers and treatments with minimum case numbers. These indicators offer the public an overview of hospital activity, whose services are largely financed by premiums and taxes. This makes it possible to choose a hospital in full knowledge of the facts. Comparisons between hospitals also feed quality discussions among specialists in professional organisations.
-    </p>
     <div class="chart-controls">
+      <div id="procedure-description" class="procedure-description fade-element"></div>
       <div class="chart-container fade-element">
         <canvas id="casesChart"></canvas>
       </div>
@@ -84,7 +82,6 @@
             </div>
           </div>
         </div>
-        <div id="procedure-description" class="procedure-description"></div>
       </div>
     </div>
   </section>

--- a/ch_hospital_de.html
+++ b/ch_hospital_de.html
@@ -37,10 +37,8 @@
       Dieser Datensatz enthält Fallzahlen der Schweizer Universitätsspitäler aus den CH‑IQI-Indikatoren.
       Die ursprünglichen Tabellen habe ich mit R-Skripten aus dem verlinkten Repository abgerufen und aufbereitet.
     </p>
-    <p class="dataset-details fade-element">
-      Die Qualitätsindikatoren der Schweizer Akutspitäler enthalten seit 2008 Daten zu Behandlungen in Schweizer Spitälern. Sie zeigen Fallzahlen, verschiedene Prozentsätze (z. B. Kaiserschnittrate), Mortalitätsraten für bestimmte Pathologien und Eingriffe sowie ausgewählte Aufenthaltsdauern, Transfers und Behandlungen mit Mindestfallzahlen. Diese Indikatoren geben der Öffentlichkeit einen Überblick über die Aktivitäten der Spitäler, deren Leistungen zu einem grossen Teil durch Prämien und Steuern finanziert werden. So kann man sein Spital fundiert wählen. Vergleiche zwischen Spitälern sollen zudem die Qualitätsdiskussionen unter Fachleuten in ihren Organisationen fördern.
-    </p>
     <div class="chart-controls">
+      <div id="procedure-description" class="procedure-description fade-element"></div>
       <div class="chart-container fade-element">
         <canvas id="casesChart"></canvas>
       </div>
@@ -83,7 +81,6 @@
             </div>
           </div>
         </div>
-        <div id="procedure-description" class="procedure-description"></div>
       </div>
     </div>
   </section>

--- a/ch_hospital_fr.html
+++ b/ch_hospital_fr.html
@@ -37,10 +37,8 @@
       Cet ensemble de données réunit les nombres de cas des hôpitaux universitaires suisses à partir des indicateurs CH‑IQI.
       J'ai extrait et restructuré les tableaux originaux à l'aide de scripts R disponibles dans le dépôt lié.
     </p>
-    <p class="dataset-details fade-element">
-      Les indicateurs de qualité des hôpitaux suisses de soins aigus contiennent des données relatives aux traitements appliqués dans les hôpitaux suisses depuis 2008. Les nombres de cas, divers pourcentages (p. ex., taux de césarienne), les taux de mortalité pour certaines pathologies et interventions ainsi que des durées de séjour sélectionnées, des transferts et des traitements avec nombre minimal de cas y sont notamment présentés. Ces indicateurs permettent tout d'abord au grand public d'avoir un aperçu de l'activité des établissements hospitaliers, les prestations desquels sont financées en grande partie par les primes et les impôts. Il est donc possible de choisir son hôpital en toute connaissance de cause. Par ailleurs, les comparaisons entre hôpitaux devraient alimenter les discussions sur la qualité menées par les spécialistes au sein des organisations professionnelles.
-    </p>
     <div class="chart-controls">
+      <div id="procedure-description" class="procedure-description fade-element"></div>
       <div class="chart-container fade-element">
         <canvas id="casesChart"></canvas>
       </div>
@@ -83,7 +81,6 @@
             </div>
           </div>
         </div>
-        <div id="procedure-description" class="procedure-description"></div>
       </div>
     </div>
   </section>

--- a/ch_hospital_it.html
+++ b/ch_hospital_it.html
@@ -37,10 +37,8 @@
       Questo set di dati raccoglie il numero di casi degli ospedali universitari svizzeri dagli indicatori CH‑IQI.
       Ho estratto e rielaborato le tabelle originali con script R disponibili nel repository collegato.
     </p>
-    <p class="dataset-details fade-element">
-      Gli indicatori di qualità degli ospedali svizzeri di cure acute contengono dati sui trattamenti effettuati negli ospedali svizzeri dal 2008. Vi si trovano numeri di casi, varie percentuali (p.es. tasso di taglio cesareo), tassi di mortalità per determinate patologie e interventi, nonché durate di degenza selezionate, trasferimenti e trattamenti con un numero minimo di casi. Questi indicatori offrono innanzitutto al grande pubblico una panoramica dell'attività degli ospedali, le cui prestazioni sono finanziate in gran parte da premi e imposte. Ciò permette di scegliere consapevolmente il proprio ospedale. Inoltre, i confronti tra ospedali alimentano le discussioni sulla qualità tra gli specialisti all'interno delle organizzazioni professionali.
-    </p>
     <div class="chart-controls">
+      <div id="procedure-description" class="procedure-description fade-element"></div>
       <div class="chart-container fade-element">
         <canvas id="casesChart"></canvas>
       </div>
@@ -83,7 +81,6 @@
             </div>
           </div>
         </div>
-        <div id="procedure-description" class="procedure-description"></div>
       </div>
     </div>
   </section>

--- a/static/css/ch_hospital.css
+++ b/static/css/ch_hospital.css
@@ -97,8 +97,7 @@ body {
   margin-bottom: 0.5rem;
 }
 
-.dataset-info,
-.dataset-details {
+.dataset-info {
   max-width: 800px;
   margin: 0.5rem auto 1rem;
   font-size: 0.95rem;
@@ -173,7 +172,7 @@ body {
 }
 
 .procedure-description {
-  margin-top: 1rem;
+  margin: 0 0 1rem;
   text-align: center;
   font-size: 0.95rem;
 }

--- a/static/js/ch_hospital.js
+++ b/static/js/ch_hospital.js
@@ -111,7 +111,7 @@ function updateChart(codes) {
   const descriptionEl = document.getElementById('procedure-description');
 
   const datasets = codes.map((code, idx) => ({
-    label: code,
+    label: procedureLabels[code][lang],
     data: cases[code],
     backgroundColor: palette[idx % palette.length][0],
     borderColor: palette[idx % palette.length][1],


### PR DESCRIPTION
## Summary
- remove long CH-IQI description paragraphs from all language pages
- show procedure names in chart legend and display full code+name above the chart
- tweak procedure description spacing

## Testing
- `npm test` *(fails: could not read package.json)*
- `npx prettier --check ch_hospital.html ch_hospital_de.html ch_hospital_fr.html ch_hospital_it.html static/js/ch_hospital.js static/css/ch_hospital.css` *(code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68c73e52b124832d860e8288fbb44c63