### PR TITLE
Add Swiss Hospital Analysis preview to navigation and home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
             </div>
           </article>
 
-          <!-- Beyond the Röstigraben -->
+          <!-- Swiss Hospital Analysis -->
           <article class="project">
             <img
               src="static/images/logos/roestigraben.png"
@@ -110,13 +110,13 @@
               loading="lazy"
             >
             <div class="project-details">
-              <h3>Beyond the Röstigraben (Preview)</h3>
+              <h3>Swiss Hospital Analysis (Preview)</h3>
               <p>
-                A personal project using Swiss public data to explore the rich
-                linguistic diversity of the country. This page is under
-                construction.
+                Dashboard comparing annual surgery cases across Switzerland's
+                university hospitals using data from the Federal Office of
+                Public Health. This page is under construction.
               </p>
-              <a href="roestigraben.html">View Preview →</a>
+              <a href="ch_hospital.html">View Preview →</a>
             </div>
           </article>
         </div>

--- a/partials/header.html
+++ b/partials/header.html
@@ -15,6 +15,7 @@
             <li><a href="easysave.html">EasySave</a></li>
             <li><a href="cognition.html">Cognition and Computation</a></li>
             <li><a href="irl.html">Reinforcement Learning</a></li>
+            <li><a href="ch_hospital.html">Swiss Hospital Analysis (Preview)</a></li>
             <li><a href="projects.html">All Projects →</a></li>
           </ul>
         </li>


### PR DESCRIPTION
## Summary
- Add Swiss Hospital Analysis (Preview) link to the Projects dropdown
- Replace Beyond the Röstigraben preview on the home page with Swiss Hospital Analysis, keeping the original logo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c742233408832d8f06b23aa104529d