### PR TITLE
Add back arrow to CH Hospital pages

### DIFF
--- a/ch_hospital.html
+++ b/ch_hospital.html
@@ -18,7 +18,11 @@
     <a href="ch_hospital_it.html" class="lang-btn">IT</a>
     <span class="lang-btn active">EN</span>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Back to homepage"></a>
+  <a href="index.html" class="back-arrow" aria-label="Back to homepage">
+    <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
+      <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </a>
 
   <section class="hero">
     <h1 class="fade-element">Swiss Hospital Analysis (CH-IQI)</h1>

--- a/ch_hospital_de.html
+++ b/ch_hospital_de.html
@@ -18,7 +18,11 @@
     <a href="ch_hospital_it.html" class="lang-btn">IT</a>
     <a href="ch_hospital.html" class="lang-btn">EN</a>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Zur Startseite"></a>
+  <a href="index.html" class="back-arrow" aria-label="Zur Startseite">
+    <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
+      <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </a>
 
   <section class="hero">
     <h1 class="fade-element">Schweizer Spitalanalyse (CH-IQI)</h1>

--- a/ch_hospital_fr.html
+++ b/ch_hospital_fr.html
@@ -18,7 +18,11 @@
     <a href="ch_hospital_it.html" class="lang-btn">IT</a>
     <a href="ch_hospital.html" class="lang-btn">EN</a>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Retour à l'accueil"></a>
+  <a href="index.html" class="back-arrow" aria-label="Retour à l'accueil">
+    <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
+      <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </a>
 
   <section class="hero">
     <h1 class="fade-element">Analyse des hôpitaux suisses (CH-IQI)</h1>

--- a/ch_hospital_it.html
+++ b/ch_hospital_it.html
@@ -18,7 +18,11 @@
     <span class="lang-btn active">IT</span>
     <a href="ch_hospital.html" class="lang-btn">EN</a>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Torna alla homepage"></a>
+  <a href="index.html" class="back-arrow" aria-label="Torna alla homepage">
+    <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
+      <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </a>
 
   <section class="hero">
     <h1 class="fade-element">Analisi degli ospedali svizzeri (CH-IQI)</h1>

--- a/static/css/ch_hospital.css
+++ b/static/css/ch_hospital.css
@@ -10,7 +10,7 @@ body {
 .language-switcher {
   position: fixed;
   top: 1rem;
-  left: 1rem;
+  left: 4rem;
   z-index: 10;
   display: flex;
   gap: 0.25rem;
@@ -34,25 +34,28 @@ body {
   background-color: #DA291C;
 }
 
-.swiss-cross {
+.back-arrow {
   position: fixed;
   top: 1rem;
-  right: 1rem;
+  left: 1rem;
   width: 2rem;
   height: 2rem;
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: #DA291C;
-  clip-path: polygon(
-    40% 0%, 60% 0%, 60% 40%, 100% 40%, 100% 60%, 60% 60%,
-    60% 100%, 40% 100%, 40% 60%, 0% 60%, 0% 40%, 40% 40%
-  );
+  border-radius: 50%;
   box-shadow: 0 0 0 2px #fff;
   z-index: 10;
   cursor: pointer;
   text-decoration: none;
   transition: transform 0.2s ease;
 }
-.swiss-cross:hover {
+.back-arrow .arrow-icon {
+  width: 1rem;
+  height: 1rem;
+}
+.back-arrow:hover {
   transform: scale(1.1);
 }
 


### PR DESCRIPTION
## Summary
- Add circular back arrow linking to homepage on CH Hospital pages
- Style arrow with Swiss red and white palette and reposition language switcher

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c74284f99c832d98996f60fa2a6eac