### PR TITLE
Fix chart responsiveness and button toggling

### DIFF
--- a/static/css/ch_hospital.css
+++ b/static/css/ch_hospital.css
@@ -203,6 +203,8 @@ body {
   margin: 0 0 1rem;
   text-align: center;
   font-size: 0.95rem;
+  height: 4.5rem;
+  overflow-y: auto;
 }
 
 .placeholder {

--- a/static/js/ch_hospital.js
+++ b/static/js/ch_hospital.js
@@ -122,34 +122,35 @@ function updateChart(codes) {
     .map(code => `${code} – ${procedureLabels[code][lang]}`)
     .join('<br>');
 
-  if (casesChart) {
-    casesChart.destroy();
-  }
-
-  casesChart = new Chart(ctx, {
-    type: 'bar',
-    data: {
-      labels: hospitalLabels,
-      datasets
-    },
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-      animation: {
-        duration: 800,
-        easing: 'easeInOutQuart'
+  if (!casesChart) {
+    casesChart = new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: hospitalLabels,
+        datasets
       },
-      scales: {
-        y: {
-          beginAtZero: true,
-          title: {
-            display: true,
-            text: yAxisLabel[lang]
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: {
+          duration: 800,
+          easing: 'easeInOutQuart'
+        },
+        scales: {
+          y: {
+            beginAtZero: true,
+            title: {
+              display: true,
+              text: yAxisLabel[lang]
+            }
           }
         }
       }
-    }
-  });
+    });
+  } else {
+    casesChart.data.datasets = datasets;
+    casesChart.update();
+  }
 }
 
 const buttons = document.querySelectorAll('.procedure-btn');
@@ -170,7 +171,7 @@ buttons.forEach(btn => {
     updateChart(Array.from(selectedCodes));
   };
 
-  btn.addEventListener('pointerdown', toggle);
+  btn.addEventListener('click', toggle);
   btn.addEventListener('keydown', e => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();


### PR DESCRIPTION
## Summary
- switch procedure buttons to `click` events for reliable toggling on mobile
- update Chart.js data in place to keep canvas size steady
- reserve space for procedure description to avoid layout jumps

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c81f307cd4832da54e53a5f72dd6d3