### PR TITLE
fix: reset deselected procedure button color

### DIFF
--- a/static/css/ch_hospital.css
+++ b/static/css/ch_hospital.css
@@ -188,10 +188,14 @@ body {
   -webkit-tap-highlight-color: transparent;
 }
 
-.procedure-btn.active,
-.procedure-btn:hover {
+.procedure-btn.active {
   background: #DA291C;
   color: #fff;
+}
+
+.procedure-btn:hover:not(.active) {
+  background: #fff;
+  color: #DA291C;
 }
 
 #casesChart {


### PR DESCRIPTION
## Summary
- ensure procedure buttons return to white when deselected

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c8214b871c832dae57deda5ac738c0