### PR TITLE
Add back arrow navigation to roestigraben pages

### DIFF
--- a/roestigraben.html
+++ b/roestigraben.html
@@ -12,11 +12,18 @@
   <link rel="stylesheet" href="static/css/roestigraben.css">
 </head>
 <body>
-  <div class="language-switcher">
-    <a href="roestigraben_de.html" class="lang-btn">DE</a>
-    <a href="roestigraben_fr.html" class="lang-btn">FR</a>
-    <a href="roestigraben_it.html" class="lang-btn">IT</a>
-    <span class="lang-btn active">EN</span>
+  <div class="header-left">
+    <a href="index.html" class="back-arrow" aria-label="Back to homepage">
+      <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
+        <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </a>
+    <div class="language-switcher">
+      <a href="roestigraben_de.html" class="lang-btn">DE</a>
+      <a href="roestigraben_fr.html" class="lang-btn">FR</a>
+      <a href="roestigraben_it.html" class="lang-btn">IT</a>
+      <span class="lang-btn active">EN</span>
+    </div>
   </div>
   <a href="index.html" class="swiss-cross" aria-label="Back to homepage"></a>
 

--- a/roestigraben_de.html
+++ b/roestigraben_de.html
@@ -12,11 +12,18 @@
   <link rel="stylesheet" href="static/css/roestigraben.css">
 </head>
 <body>
-  <div class="language-switcher">
-    <span class="lang-btn active">DE</span>
-    <a href="roestigraben_fr.html" class="lang-btn">FR</a>
-    <a href="roestigraben_it.html" class="lang-btn">IT</a>
-    <a href="roestigraben.html" class="lang-btn">EN</a>
+  <div class="header-left">
+    <a href="index.html" class="back-arrow" aria-label="Zur Startseite">
+      <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
+        <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </a>
+    <div class="language-switcher">
+      <span class="lang-btn active">DE</span>
+      <a href="roestigraben_fr.html" class="lang-btn">FR</a>
+      <a href="roestigraben_it.html" class="lang-btn">IT</a>
+      <a href="roestigraben.html" class="lang-btn">EN</a>
+    </div>
   </div>
   <a href="index.html" class="swiss-cross" aria-label="Zur Startseite"></a>
 

--- a/roestigraben_fr.html
+++ b/roestigraben_fr.html
@@ -12,11 +12,18 @@
   <link rel="stylesheet" href="static/css/roestigraben.css">
 </head>
 <body>
-  <div class="language-switcher">
-    <a href="roestigraben_de.html" class="lang-btn">DE</a>
-    <span class="lang-btn active">FR</span>
-    <a href="roestigraben_it.html" class="lang-btn">IT</a>
-    <a href="roestigraben.html" class="lang-btn">EN</a>
+  <div class="header-left">
+    <a href="index.html" class="back-arrow" aria-label="Retour à l'accueil">
+      <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
+        <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </a>
+    <div class="language-switcher">
+      <a href="roestigraben_de.html" class="lang-btn">DE</a>
+      <span class="lang-btn active">FR</span>
+      <a href="roestigraben_it.html" class="lang-btn">IT</a>
+      <a href="roestigraben.html" class="lang-btn">EN</a>
+    </div>
   </div>
   <a href="index.html" class="swiss-cross" aria-label="Retour à l'accueil"></a>
 

--- a/roestigraben_it.html
+++ b/roestigraben_it.html
@@ -12,11 +12,18 @@
   <link rel="stylesheet" href="static/css/roestigraben.css">
 </head>
 <body>
-  <div class="language-switcher">
-    <a href="roestigraben_de.html" class="lang-btn">DE</a>
-    <a href="roestigraben_fr.html" class="lang-btn">FR</a>
-    <span class="lang-btn active">IT</span>
-    <a href="roestigraben.html" class="lang-btn">EN</a>
+  <div class="header-left">
+    <a href="index.html" class="back-arrow" aria-label="Torna alla home page">
+      <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
+        <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </a>
+    <div class="language-switcher">
+      <a href="roestigraben_de.html" class="lang-btn">DE</a>
+      <a href="roestigraben_fr.html" class="lang-btn">FR</a>
+      <span class="lang-btn active">IT</span>
+      <a href="roestigraben.html" class="lang-btn">EN</a>
+    </div>
   </div>
   <a href="index.html" class="swiss-cross" aria-label="Torna alla home page"></a>
 

--- a/static/css/roestigraben.css
+++ b/static/css/roestigraben.css
@@ -11,12 +11,38 @@ body {
   overflow-x: hidden;
   position: relative;
 }
-/* Language switcher */
-.language-switcher {
+/* Back arrow and language switcher */
+.header-left {
   position: fixed;
   top: 1rem;
   left: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
   z-index: 10;
+}
+.back-arrow {
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #DA291C;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px #fff;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.2s ease;
+}
+.back-arrow .arrow-icon {
+  width: 1rem;
+  height: 1rem;
+}
+.back-arrow:hover {
+  transform: scale(1.1);
+}
+.language-switcher {
+  position: relative;
   display: flex;
   gap: 0.25rem;
   background: rgba(255, 255, 255, 0.85);


### PR DESCRIPTION
## Summary
- Add back arrow and header container to all roestigraben pages for easy navigation back to homepage.
- Introduce matching CSS styles for new back arrow and layout.

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c822816104832d9ac67348032088ad