### PR TITLE
Organize project pages under pages/projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
                 forecasts. Developed for the Software Development course in
                 collaboration with other students.
               </p>
-              <a href="easysave.html">View Project →</a>
+              <a href="/pages/projects/easysave.html">View Project →</a>
             </div>
           </article>
 
@@ -97,7 +97,7 @@
                 science, including memory models, language segmentation,
                 decision-making simulations, and connectionist networks.
               </p>
-              <a href="cognition.html">View Project →</a>
+              <a href="/pages/projects/cognition.html">View Project →</a>
             </div>
           </article>
 

--- a/pages/projects/cognition.html
+++ b/pages/projects/cognition.html
@@ -9,9 +9,9 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="static/css/styles.css">
-  <script src="static/js/script.js" defer></script>
-  <script src="static/js/includes.js" defer></script>
+  <link rel="stylesheet" href="/static/css/styles.css">
+  <script src="/static/js/script.js" defer></script>
+  <script src="/static/js/includes.js" defer></script>
 </head>
 <body>
   <div class="container">
@@ -64,7 +64,7 @@
         <div class="assignment-pdf">
           <div class="pdf-container">
             <iframe
-              src="static/pdf/cognition/CC-A1-report.pdf#navpanes=0"
+              src="/static/pdf/cognition/CC-A1-report.pdf#navpanes=0"
               title="Assignment 1 Report"
               loading="lazy">
             </iframe>
@@ -91,7 +91,7 @@
         <div class="assignment-pdf">
           <div class="pdf-container">
             <iframe
-              src="static/pdf/cognition/CC-A2-report.pdf#navpanes=0"
+              src="/static/pdf/cognition/CC-A2-report.pdf#navpanes=0"
               title="Assignment 2 Report"
               loading="lazy">
             </iframe>
@@ -110,7 +110,7 @@
         <div class="assignment-pdf">
           <div class="pdf-container">
             <iframe
-              src="static/pdf/cognition/CC-A3-report.pdf#navpanes=0"
+              src="/static/pdf/cognition/CC-A3-report.pdf#navpanes=0"
               title="Assignment 3 Report"
               loading="lazy">
             </iframe>
@@ -129,7 +129,7 @@
         <div class="assignment-pdf">
           <div class="pdf-container">
             <iframe
-              src="static/pdf/cognition/CC-A4-report.pdf#navpanes=0"
+              src="/static/pdf/cognition/CC-A4-report.pdf#navpanes=0"
               title="Assignment 4 Report"
               loading="lazy">
             </iframe>

--- a/pages/projects/easysave.html
+++ b/pages/projects/easysave.html
@@ -9,10 +9,10 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="static/css/styles.css">
-  <link rel='stylesheet' href='static/css/easysave.css'>
-  <script src="static/js/script.js" defer></script>
-  <script src="static/js/includes.js" defer></script>
+  <link rel="stylesheet" href="/static/css/styles.css">
+  <link rel='stylesheet' href='/static/css/easysave.css'>
+  <script src="/static/js/script.js" defer></script>
+  <script src="/static/js/includes.js" defer></script>
 </head>
 <body>
   <div class="container">
@@ -22,7 +22,7 @@
       <!-- Hero -->
       <section id="hero" class="section section--full" data-bg="#f3ede6">
         <div class="fade-element logo-container">
-          <img src="static/images/easysave/logo.png" alt="EasySave Logo" />
+          <img src="/static/images/easysave/logo.png" alt="EasySave Logo" />
         </div>
         <p class="fade-element subtitle">AI-Powered Student Financial Planner</p>
         <p class="repo-link fade-element"><a href="https://github.com/joonhaim/EasySave" target="_blank" rel="noopener">View on GitHub →</a></p>
@@ -37,7 +37,7 @@
           <p>EasySave analyzes your income and past spending to craft a custom savings roadmap. Rather than one‑size‑fits‑all advice, you get recommendations that adapt to exactly how and when you spend. Every morning, you’ll see a precise ‘spend‑up‑to’ amount for the day, calculated from your goals and historic habits. Think of it as your pocket‑sized spending coach.</p>
         </div>
         <div class="image fade-element">
-          <img src="static/images/easysave/homepage_screenshot.png" alt="Daily Budget screenshot">
+          <img src="/static/images/easysave/homepage_screenshot.png" alt="Daily Budget screenshot">
         </div>
       </section>
 
@@ -47,7 +47,7 @@
           <p>Every time you log an expense, your dashboard updates instantly. Charts, progress bars and peer-comparison markers all reflect your changes in real time, so you always have a clear picture of where you stand. It’s like having a financial companion that reacts the moment you take action.</p>
         </div>
         <div class="image fade-element">
-          <img src="static/images/easysave/interactive.png" alt="Dashboard screenshot">
+          <img src="/static/images/easysave/interactive.png" alt="Dashboard screenshot">
         </div>
       </section>
 
@@ -57,7 +57,7 @@
           <p>You can set weekly or monthly savings targets and see your progress come to life with simple, visual trackers. Whether it’s a progress ring or a milestone bar, EasySave turns numbers into something you can understand and follow. Reaching your goals becomes less about guessing and more about taking clear steps forward.</p>
         </div>
         <div class="image fade-element">
-          <img src="static/images/easysave/saving_goals_screenshot.png" alt="Goal Tracking screenshot">
+          <img src="/static/images/easysave/saving_goals_screenshot.png" alt="Goal Tracking screenshot">
         </div>
       </section>
 
@@ -67,7 +67,7 @@
           <p>Explore your spending habits in detail with clear, easy-to-read graphs. You can filter by category or time period to uncover patterns and find areas where you might be overspending. This makes it much easier to make small, mindful changes that add up over time.</p>
         </div>
         <div class="image fade-element">
-          <img src="static/images/easysave/detailed_data_page_screenshot.png" alt="Analysis screenshot">
+          <img src="/static/images/easysave/detailed_data_page_screenshot.png" alt="Analysis screenshot">
         </div>
       </section>
 
@@ -77,7 +77,7 @@
           <p>EasySave uses an ARIMA-based forecasting model to give you a clear preview of next month’s spending. This advanced statistical approach looks at your past habits to predict future trends, highlighting categories where you might overshoot your goals. By seeing potential problem areas early, you can adjust today and avoid surprises later.</p>
         </div>
         <div class="image fade-element">
-          <img src="static/images/easysave/predictions.png" alt="Placeholder for Predictions screenshot">
+          <img src="/static/images/easysave/predictions.png" alt="Placeholder for Predictions screenshot">
         </div>
       </section>
 
@@ -87,7 +87,7 @@
           <p>Manage all your personal details in one place, from your profile information to your app preferences. You can switch between themes, choose your preferred language and adjust notifications so EasySave works exactly how you want it to.</p>
         </div>
         <div class="image fade-element">
-          <img src="static/images/easysave/user_profile_screenshot.png" alt="Profile Settings screenshot">
+          <img src="/static/images/easysave/user_profile_screenshot.png" alt="Profile Settings screenshot">
         </div>
       </section>
 

--- a/pages/projects/roestigraben.html
+++ b/pages/projects/roestigraben.html
@@ -9,11 +9,11 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="static/css/roestigraben.css">
+  <link rel="stylesheet" href="/static/css/roestigraben.css">
 </head>
 <body>
   <div class="header-left">
-    <a href="index.html" class="back-arrow" aria-label="Back to homepage">
+    <a href="/index.html" class="back-arrow" aria-label="Back to homepage">
       <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
         <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
@@ -25,7 +25,7 @@
       <span class="lang-btn active">EN</span>
     </div>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Back to homepage"></a>
+  <a href="/index.html" class="swiss-cross" aria-label="Back to homepage"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">
     <h1 class="fade-element">Beyond<br>the<br>Röstigraben</h1>
@@ -40,7 +40,7 @@
       <p>From single-language bastions to multicultural communities, discover where Switzerland speaks with one voice and where many tongues mingle.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Social Trends Map" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Social Trends Map" class="map">
     </div>
   </section>
 
@@ -50,7 +50,7 @@
       <p>What can surnames reveal about linguistic identity? We compare the origins of common names with the languages spoken locally.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Cultural Map" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Cultural Map" class="map">
     </div>
   </section>
 
@@ -60,7 +60,7 @@
       <p>Migration and demographics continually reshape the linguistic balance. Follow the rise and fall of German, French, Italian and more across recent decades.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Economic Map" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Economic Map" class="map">
     </div>
   </section>
 
@@ -70,11 +70,11 @@
       <p>Does multilingualism fuel prosperity? Explore links between language variety and income, employment and housing across regions.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Political Map" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Political Map" class="map">
     </div>
   </section>
 
-  <script src="static/js/roestigraben.js"></script>
+  <script src="/static/js/roestigraben.js"></script>
 </body>
 </html>
 

--- a/pages/projects/roestigraben_de.html
+++ b/pages/projects/roestigraben_de.html
@@ -9,11 +9,11 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="static/css/roestigraben.css">
+  <link rel="stylesheet" href="/static/css/roestigraben.css">
 </head>
 <body>
   <div class="header-left">
-    <a href="index.html" class="back-arrow" aria-label="Zur Startseite">
+    <a href="/index.html" class="back-arrow" aria-label="Zur Startseite">
       <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
         <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
@@ -25,7 +25,7 @@
       <a href="roestigraben.html" class="lang-btn">EN</a>
     </div>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Zur Startseite"></a>
+  <a href="/index.html" class="swiss-cross" aria-label="Zur Startseite"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">
     <h1 class="fade-element">Jenseits<br>des<br>Röstigrabens</h1>
@@ -40,7 +40,7 @@
       <p>Von einsprachigen Bastionen bis zu mehrsprachigen Gemeinden – entdecken Sie, wo die Schweiz mit einer Stimme spricht und wo viele Sprachen aufeinandertreffen.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Soziokarte" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Soziokarte" class="map">
     </div>
   </section>
 
@@ -50,7 +50,7 @@
       <p>Was verraten Nachnamen über die sprachliche Identität? Wir vergleichen die Herkunft häufiger Namen mit den vor Ort gesprochenen Sprachen.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Kulturkarte" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Kulturkarte" class="map">
     </div>
   </section>
 
@@ -60,7 +60,7 @@
       <p>Migration und Demografie verändern die sprachliche Balance stetig. Verfolgen Sie den Aufstieg und Fall von Deutsch, Französisch, Italienisch und mehr über die letzten Jahrzehnte.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Zeitkarte" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Zeitkarte" class="map">
     </div>
   </section>
 
@@ -70,11 +70,11 @@
       <p>Fördert Mehrsprachigkeit den Wohlstand? Entdecken Sie Zusammenhänge zwischen sprachlicher Vielfalt und Einkommen, Beschäftigung sowie Wohnen in den Regionen.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Wirtschaftskarte" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Wirtschaftskarte" class="map">
     </div>
   </section>
 
-  <script src="static/js/roestigraben.js"></script>
+  <script src="/static/js/roestigraben.js"></script>
 </body>
 </html>
 

--- a/pages/projects/roestigraben_fr.html
+++ b/pages/projects/roestigraben_fr.html
@@ -9,11 +9,11 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="static/css/roestigraben.css">
+  <link rel="stylesheet" href="/static/css/roestigraben.css">
 </head>
 <body>
   <div class="header-left">
-    <a href="index.html" class="back-arrow" aria-label="Retour à l'accueil">
+    <a href="/index.html" class="back-arrow" aria-label="Retour à l'accueil">
       <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
         <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
@@ -25,7 +25,7 @@
       <a href="roestigraben.html" class="lang-btn">EN</a>
     </div>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Retour à l'accueil"></a>
+  <a href="/index.html" class="swiss-cross" aria-label="Retour à l'accueil"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">
     <h1 class="fade-element">Au-delà<br>du<br>Röstigraben</h1>
@@ -40,7 +40,7 @@
       <p>Des bastions monolingues aux communes multiculturelles, découvrez où la Suisse parle d’une seule voix et où se mêlent plusieurs langues.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Carte sociale" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Carte sociale" class="map">
     </div>
   </section>
 
@@ -50,7 +50,7 @@
       <p>Que révèlent les noms de famille sur l’identité linguistique ? Nous comparons l’origine des noms courants aux langues parlées localement.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Carte culturelle" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Carte culturelle" class="map">
     </div>
   </section>
 
@@ -60,7 +60,7 @@
       <p>Migrations et démographie redessinent sans cesse l’équilibre linguistique. Suivez l’essor ou le déclin de l’allemand, du français, de l’italien et d’autres langues au fil des décennies.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Carte temporelle" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Carte temporelle" class="map">
     </div>
   </section>
 
@@ -70,11 +70,11 @@
       <p>Le multilinguisme favorise-t-il la prospérité ? Explorez les liens entre diversité linguistique et revenus, emploi et logement selon les régions.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Carte économique" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Carte économique" class="map">
     </div>
   </section>
 
-  <script src="static/js/roestigraben.js"></script>
+  <script src="/static/js/roestigraben.js"></script>
 </body>
 </html>
 

--- a/pages/projects/roestigraben_it.html
+++ b/pages/projects/roestigraben_it.html
@@ -9,11 +9,11 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="static/css/roestigraben.css">
+  <link rel="stylesheet" href="/static/css/roestigraben.css">
 </head>
 <body>
   <div class="header-left">
-    <a href="index.html" class="back-arrow" aria-label="Torna alla home page">
+    <a href="/index.html" class="back-arrow" aria-label="Torna alla home page">
       <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
         <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
@@ -25,7 +25,7 @@
       <a href="roestigraben.html" class="lang-btn">EN</a>
     </div>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Torna alla home page"></a>
+  <a href="/index.html" class="swiss-cross" aria-label="Torna alla home page"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">
     <h1 class="fade-element">Oltre<br>il<br>Röstigraben</h1>
@@ -40,7 +40,7 @@
       <p>Dalle roccaforti monolingui alle comunità multiculturali: scoprite dove la Svizzera parla con una sola voce e dove convivono molte lingue.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Mappa sociale" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Mappa sociale" class="map">
     </div>
   </section>
 
@@ -50,7 +50,7 @@
       <p>Cosa possono rivelare i cognomi sull’identità linguistica? Confrontiamo l’origine dei nomi più diffusi con le lingue parlate a livello locale.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Mappa culturale" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Mappa culturale" class="map">
     </div>
   </section>
 
@@ -60,7 +60,7 @@
       <p>Migrazioni e demografia modificano continuamente l’equilibrio linguistico. Seguite l’ascesa e il declino di tedesco, francese, italiano e altre lingue negli ultimi decenni.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Mappa temporale" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Mappa temporale" class="map">
     </div>
   </section>
 
@@ -70,11 +70,11 @@
       <p>Il multilinguismo alimenta la prosperità? Esplorate i legami tra varietà linguistica e reddito, occupazione e abitazioni nelle diverse regioni.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Mappa economica" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Mappa economica" class="map">
     </div>
   </section>
 
-  <script src="static/js/roestigraben.js"></script>
+  <script src="/static/js/roestigraben.js"></script>
 </body>
 </html>
 

--- a/partials/header.html
+++ b/partials/header.html
@@ -6,20 +6,20 @@
     <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">☰ Menu</button>
     <nav class="main-nav">
       <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About</a></li>
+        <li><a href="/index.html">Home</a></li>
+        <li><a href="/about.html">About</a></li>
         <!-- Projects dropdown -->
         <li class="has-dropdown">
-          <a href="projects.html">Projects<span class="arrow">▾</span></a>
+          <a href="/projects.html">Projects<span class="arrow">▾</span></a>
           <ul class="dropdown-menu">
-            <li><a href="easysave.html">EasySave</a></li>
-            <li><a href="cognition.html">Cognition and Computation</a></li>
-            <li><a href="irl.html">Reinforcement Learning</a></li>
-            <li><a href="ch_hospital.html">Swiss Hospital Insights</a></li>
-            <li><a href="projects.html">All Projects →</a></li>
+            <li><a href="/pages/projects/easysave.html">EasySave</a></li>
+            <li><a href="/pages/projects/cognition.html">Cognition and Computation</a></li>
+            <li><a href="/irl.html">Reinforcement Learning</a></li>
+            <li><a href="/ch_hospital.html">Swiss Hospital Insights</a></li>
+            <li><a href="/projects.html">All Projects →</a></li>
           </ul>
         </li>
-        <li><a href="contact.html">Contact</a></li>
+        <li><a href="/contact.html">Contact</a></li>
       </ul>
     </nav>
   </header>

--- a/projects.html
+++ b/projects.html
@@ -60,7 +60,7 @@
               <p>
                 AI-powered student financial planner with personalized savings plans, daily spending limits, peer comparisons, and spending forecasts. Developed collaboratively for the Software Development course.
               </p>
-              <a href="easysave.html">View Project →</a>
+              <a href="/pages/projects/easysave.html">View Project →</a>
             </div>
           </article>
 
@@ -71,7 +71,7 @@
               <p>
                 Course assignments showcasing computational models in cognitive science: memory simulations, language segmentation, decision-making models, and connectionist networks.
               </p>
-              <a href="cognition.html">View Project →</a>
+              <a href="/pages/projects/cognition.html">View Project →</a>
             </div>
           </article>
 
@@ -114,7 +114,7 @@
               <p>
                 A personal exploration of Switzerland’s linguistic diversity using public data. This page is under construction and will feature interactive maps and analyses.
               </p>
-              <a href="roestigraben.html">View Preview →</a>
+              <a href="/pages/projects/roestigraben.html">View Preview →</a>
             </div>
           </article>
 

--- a/static/js/includes.js
+++ b/static/js/includes.js
@@ -6,14 +6,15 @@ document.addEventListener('DOMContentLoaded', () => {
         .catch(err => console.error(`Error loading ${url}:`, err));
   
     // inject header & footer
-    const headerLoaded = load('#site-header', 'partials/header.html');
-    load('#site-footer', 'partials/footer.html');
+    const headerLoaded = load('#site-header', '/partials/header.html');
+    load('#site-footer', '/partials/footer.html');
 
   // once header is in place, highlight active link and enable mobile nav
   headerLoaded.then(() => {
-    const path = location.pathname.split('/').pop() || 'index.html';
+    let current = location.pathname;
+    if (current === '/') current = '/index.html';
     document.querySelectorAll('.main-nav a').forEach(a => {
-      if (a.getAttribute('href') === path) a.classList.add('active');
+      if (a.getAttribute('href') === current) a.classList.add('active');
     });
 
     const navToggle = document.getElementById('nav-toggle');


### PR DESCRIPTION
## Summary
- Move project pages like Cognition, EasySave, and multilingual Röstigraben into a new `pages/projects` directory
- Update navigation, index, and project listings to point to relocated pages with root-relative URLs
- Fetch header/footer via absolute paths and improve active-link handling in `includes.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c82563e43c832d999e29ee41455947