### PR TITLE
Organize localized pages into language directories

### DIFF
--- a/ch_hospital/de/index.html
+++ b/ch_hospital/de/index.html
@@ -9,23 +9,23 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="static/css/ch_hospital.css">
+  <link rel="stylesheet" href="/static/css/ch_hospital.css">
 </head>
 <body>
   <div class="header-left">
-    <a href="index.html" class="back-arrow" aria-label="Zur Startseite">
+    <a href="/index.html" class="back-arrow" aria-label="Zur Startseite">
       <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
         <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </a>
     <div class="language-switcher">
       <span class="lang-btn active">DE</span>
-      <a href="ch_hospital_fr.html" class="lang-btn">FR</a>
-      <a href="ch_hospital_it.html" class="lang-btn">IT</a>
-      <a href="ch_hospital.html" class="lang-btn">EN</a>
+      <a href="/ch_hospital/fr/" class="lang-btn">FR</a>
+      <a href="/ch_hospital/it/" class="lang-btn">IT</a>
+      <a href="/ch_hospital/" class="lang-btn">EN</a>
     </div>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Zur Startseite"></a>
+  <a href="/index.html" class="swiss-cross" aria-label="Zur Startseite"></a>
 
   <section class="hero">
     <h1 class="fade-element">Schweizer Spitalanalyse (CH-IQI)</h1>
@@ -103,6 +103,6 @@
   </section>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script src="static/js/ch_hospital.js"></script>
+  <script src="/static/js/ch_hospital.js"></script>
 </body>
 </html>

--- a/ch_hospital/fr/index.html
+++ b/ch_hospital/fr/index.html
@@ -9,23 +9,23 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="static/css/ch_hospital.css">
+  <link rel="stylesheet" href="/static/css/ch_hospital.css">
 </head>
 <body>
   <div class="header-left">
-    <a href="index.html" class="back-arrow" aria-label="Retour à l'accueil">
+    <a href="/index.html" class="back-arrow" aria-label="Retour à l'accueil">
       <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
         <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </a>
     <div class="language-switcher">
-      <a href="ch_hospital_de.html" class="lang-btn">DE</a>
+      <a href="/ch_hospital/de/" class="lang-btn">DE</a>
       <span class="lang-btn active">FR</span>
-      <a href="ch_hospital_it.html" class="lang-btn">IT</a>
-      <a href="ch_hospital.html" class="lang-btn">EN</a>
+      <a href="/ch_hospital/it/" class="lang-btn">IT</a>
+      <a href="/ch_hospital/" class="lang-btn">EN</a>
     </div>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Retour à l'accueil"></a>
+  <a href="/index.html" class="swiss-cross" aria-label="Retour à l'accueil"></a>
 
   <section class="hero">
     <h1 class="fade-element">Analyse des hôpitaux suisses (CH-IQI)</h1>
@@ -103,6 +103,6 @@
   </section>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script src="static/js/ch_hospital.js"></script>
+  <script src="/static/js/ch_hospital.js"></script>
 </body>
 </html>

--- a/ch_hospital/index.html
+++ b/ch_hospital/index.html
@@ -9,23 +9,23 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="static/css/ch_hospital.css">
+  <link rel="stylesheet" href="/static/css/ch_hospital.css">
 </head>
 <body>
   <div class="header-left">
-    <a href="index.html" class="back-arrow" aria-label="Back to homepage">
+    <a href="/index.html" class="back-arrow" aria-label="Back to homepage">
       <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
         <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </a>
     <div class="language-switcher">
-      <a href="ch_hospital_de.html" class="lang-btn">DE</a>
-      <a href="ch_hospital_fr.html" class="lang-btn">FR</a>
-      <a href="ch_hospital_it.html" class="lang-btn">IT</a>
+      <a href="/ch_hospital/de/" class="lang-btn">DE</a>
+      <a href="/ch_hospital/fr/" class="lang-btn">FR</a>
+      <a href="/ch_hospital/it/" class="lang-btn">IT</a>
       <span class="lang-btn active">EN</span>
     </div>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Back to homepage"></a>
+  <a href="/index.html" class="swiss-cross" aria-label="Back to homepage"></a>
 
   <section class="hero">
     <h1 class="fade-element">Swiss Hospital Insights (CH-IQI)</h1>
@@ -104,6 +104,6 @@
   </section>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script src="static/js/ch_hospital.js"></script>
+  <script src="/static/js/ch_hospital.js"></script>
 </body>
 </html>

--- a/ch_hospital/it/index.html
+++ b/ch_hospital/it/index.html
@@ -9,23 +9,23 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="static/css/ch_hospital.css">
+  <link rel="stylesheet" href="/static/css/ch_hospital.css">
 </head>
 <body>
   <div class="header-left">
-    <a href="index.html" class="back-arrow" aria-label="Torna alla homepage">
+    <a href="/index.html" class="back-arrow" aria-label="Torna alla homepage">
       <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
         <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </a>
     <div class="language-switcher">
-      <a href="ch_hospital_de.html" class="lang-btn">DE</a>
-      <a href="ch_hospital_fr.html" class="lang-btn">FR</a>
+      <a href="/ch_hospital/de/" class="lang-btn">DE</a>
+      <a href="/ch_hospital/fr/" class="lang-btn">FR</a>
       <span class="lang-btn active">IT</span>
-      <a href="ch_hospital.html" class="lang-btn">EN</a>
+      <a href="/ch_hospital/" class="lang-btn">EN</a>
     </div>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Torna alla homepage"></a>
+  <a href="/index.html" class="swiss-cross" aria-label="Torna alla homepage"></a>
 
   <section class="hero">
     <h1 class="fade-element">Analisi degli ospedali svizzeri (CH-IQI)</h1>
@@ -103,6 +103,6 @@
   </section>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script src="static/js/ch_hospital.js"></script>
+  <script src="/static/js/ch_hospital.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
                 university hospitals using data from the Federal Office of
                 Public Health. This page is under construction.
               </p>
-              <a href="ch_hospital.html">View Preview →</a>
+              <a href="ch_hospital/">View Preview →</a>
             </div>
           </article>
         </div>

--- a/partials/header.html
+++ b/partials/header.html
@@ -15,7 +15,7 @@
             <li><a href="easysave.html">EasySave</a></li>
             <li><a href="cognition.html">Cognition and Computation</a></li>
             <li><a href="irl.html">Reinforcement Learning</a></li>
-            <li><a href="ch_hospital.html">Swiss Hospital Insights</a></li>
+            <li><a href="ch_hospital/">Swiss Hospital Insights</a></li>
             <li><a href="projects.html">All Projects →</a></li>
           </ul>
         </li>

--- a/projects.html
+++ b/projects.html
@@ -114,7 +114,7 @@
               <p>
                 A personal exploration of Switzerland’s linguistic diversity using public data. This page is under construction and will feature interactive maps and analyses.
               </p>
-              <a href="roestigraben.html">View Preview →</a>
+              <a href="roestigraben/">View Preview →</a>
             </div>
           </article>
 
@@ -125,7 +125,7 @@
               <p>
                   Dashboard comparing annual surgery cases across Switzerland's university hospitals using data from the Federal office of Public Health (FOPH).
               </p>
-              <a href="ch_hospital.html">View Project →</a>
+              <a href="ch_hospital/">View Project →</a>
             </div>
           </article>
 

--- a/roestigraben/de/index.html
+++ b/roestigraben/de/index.html
@@ -9,23 +9,23 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="static/css/roestigraben.css">
+  <link rel="stylesheet" href="/static/css/roestigraben.css">
 </head>
 <body>
   <div class="header-left">
-    <a href="index.html" class="back-arrow" aria-label="Zur Startseite">
+    <a href="/index.html" class="back-arrow" aria-label="Zur Startseite">
       <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
         <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </a>
     <div class="language-switcher">
       <span class="lang-btn active">DE</span>
-      <a href="roestigraben_fr.html" class="lang-btn">FR</a>
-      <a href="roestigraben_it.html" class="lang-btn">IT</a>
-      <a href="roestigraben.html" class="lang-btn">EN</a>
+      <a href="/roestigraben/fr/" class="lang-btn">FR</a>
+      <a href="/roestigraben/it/" class="lang-btn">IT</a>
+      <a href="/roestigraben/" class="lang-btn">EN</a>
     </div>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Zur Startseite"></a>
+  <a href="/index.html" class="swiss-cross" aria-label="Zur Startseite"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">
     <h1 class="fade-element">Jenseits<br>des<br>Röstigrabens</h1>
@@ -40,7 +40,7 @@
       <p>Von einsprachigen Bastionen bis zu mehrsprachigen Gemeinden – entdecken Sie, wo die Schweiz mit einer Stimme spricht und wo viele Sprachen aufeinandertreffen.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Soziokarte" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Soziokarte" class="map">
     </div>
   </section>
 
@@ -50,7 +50,7 @@
       <p>Was verraten Nachnamen über die sprachliche Identität? Wir vergleichen die Herkunft häufiger Namen mit den vor Ort gesprochenen Sprachen.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Kulturkarte" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Kulturkarte" class="map">
     </div>
   </section>
 
@@ -60,7 +60,7 @@
       <p>Migration und Demografie verändern die sprachliche Balance stetig. Verfolgen Sie den Aufstieg und Fall von Deutsch, Französisch, Italienisch und mehr über die letzten Jahrzehnte.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Zeitkarte" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Zeitkarte" class="map">
     </div>
   </section>
 
@@ -70,11 +70,11 @@
       <p>Fördert Mehrsprachigkeit den Wohlstand? Entdecken Sie Zusammenhänge zwischen sprachlicher Vielfalt und Einkommen, Beschäftigung sowie Wohnen in den Regionen.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Wirtschaftskarte" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Wirtschaftskarte" class="map">
     </div>
   </section>
 
-  <script src="static/js/roestigraben.js"></script>
+  <script src="/static/js/roestigraben.js"></script>
 </body>
 </html>
 

--- a/roestigraben/fr/index.html
+++ b/roestigraben/fr/index.html
@@ -9,23 +9,23 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="static/css/roestigraben.css">
+  <link rel="stylesheet" href="/static/css/roestigraben.css">
 </head>
 <body>
   <div class="header-left">
-    <a href="index.html" class="back-arrow" aria-label="Retour à l'accueil">
+    <a href="/index.html" class="back-arrow" aria-label="Retour à l'accueil">
       <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
         <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </a>
     <div class="language-switcher">
-      <a href="roestigraben_de.html" class="lang-btn">DE</a>
+      <a href="/roestigraben/de/" class="lang-btn">DE</a>
       <span class="lang-btn active">FR</span>
-      <a href="roestigraben_it.html" class="lang-btn">IT</a>
-      <a href="roestigraben.html" class="lang-btn">EN</a>
+      <a href="/roestigraben/it/" class="lang-btn">IT</a>
+      <a href="/roestigraben/" class="lang-btn">EN</a>
     </div>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Retour à l'accueil"></a>
+  <a href="/index.html" class="swiss-cross" aria-label="Retour à l'accueil"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">
     <h1 class="fade-element">Au-delà<br>du<br>Röstigraben</h1>
@@ -40,7 +40,7 @@
       <p>Des bastions monolingues aux communes multiculturelles, découvrez où la Suisse parle d’une seule voix et où se mêlent plusieurs langues.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Carte sociale" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Carte sociale" class="map">
     </div>
   </section>
 
@@ -50,7 +50,7 @@
       <p>Que révèlent les noms de famille sur l’identité linguistique ? Nous comparons l’origine des noms courants aux langues parlées localement.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Carte culturelle" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Carte culturelle" class="map">
     </div>
   </section>
 
@@ -60,7 +60,7 @@
       <p>Migrations et démographie redessinent sans cesse l’équilibre linguistique. Suivez l’essor ou le déclin de l’allemand, du français, de l’italien et d’autres langues au fil des décennies.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Carte temporelle" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Carte temporelle" class="map">
     </div>
   </section>
 
@@ -70,11 +70,11 @@
       <p>Le multilinguisme favorise-t-il la prospérité ? Explorez les liens entre diversité linguistique et revenus, emploi et logement selon les régions.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Carte économique" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Carte économique" class="map">
     </div>
   </section>
 
-  <script src="static/js/roestigraben.js"></script>
+  <script src="/static/js/roestigraben.js"></script>
 </body>
 </html>
 

--- a/roestigraben/index.html
+++ b/roestigraben/index.html
@@ -9,23 +9,23 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="static/css/roestigraben.css">
+  <link rel="stylesheet" href="/static/css/roestigraben.css">
 </head>
 <body>
   <div class="header-left">
-    <a href="index.html" class="back-arrow" aria-label="Back to homepage">
+    <a href="/index.html" class="back-arrow" aria-label="Back to homepage">
       <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
         <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </a>
     <div class="language-switcher">
-      <a href="roestigraben_de.html" class="lang-btn">DE</a>
-      <a href="roestigraben_fr.html" class="lang-btn">FR</a>
-      <a href="roestigraben_it.html" class="lang-btn">IT</a>
+      <a href="/roestigraben/de/" class="lang-btn">DE</a>
+      <a href="/roestigraben/fr/" class="lang-btn">FR</a>
+      <a href="/roestigraben/it/" class="lang-btn">IT</a>
       <span class="lang-btn active">EN</span>
     </div>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Back to homepage"></a>
+  <a href="/index.html" class="swiss-cross" aria-label="Back to homepage"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">
     <h1 class="fade-element">Beyond<br>the<br>Röstigraben</h1>
@@ -40,7 +40,7 @@
       <p>From single-language bastions to multicultural communities, discover where Switzerland speaks with one voice and where many tongues mingle.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Social Trends Map" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Social Trends Map" class="map">
     </div>
   </section>
 
@@ -50,7 +50,7 @@
       <p>What can surnames reveal about linguistic identity? We compare the origins of common names with the languages spoken locally.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Cultural Map" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Cultural Map" class="map">
     </div>
   </section>
 
@@ -60,7 +60,7 @@
       <p>Migration and demographics continually reshape the linguistic balance. Follow the rise and fall of German, French, Italian and more across recent decades.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Economic Map" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Economic Map" class="map">
     </div>
   </section>
 
@@ -70,11 +70,11 @@
       <p>Does multilingualism fuel prosperity? Explore links between language variety and income, employment and housing across regions.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Political Map" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Political Map" class="map">
     </div>
   </section>
 
-  <script src="static/js/roestigraben.js"></script>
+  <script src="/static/js/roestigraben.js"></script>
 </body>
 </html>
 

--- a/roestigraben/it/index.html
+++ b/roestigraben/it/index.html
@@ -9,23 +9,23 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="static/css/roestigraben.css">
+  <link rel="stylesheet" href="/static/css/roestigraben.css">
 </head>
 <body>
   <div class="header-left">
-    <a href="index.html" class="back-arrow" aria-label="Torna alla home page">
+    <a href="/index.html" class="back-arrow" aria-label="Torna alla home page">
       <svg viewBox="0 0 24 24" class="arrow-icon" xmlns="http://www.w3.org/2000/svg">
         <path d="M15 6L9 12l6 6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </a>
     <div class="language-switcher">
-      <a href="roestigraben_de.html" class="lang-btn">DE</a>
-      <a href="roestigraben_fr.html" class="lang-btn">FR</a>
+      <a href="/roestigraben/de/" class="lang-btn">DE</a>
+      <a href="/roestigraben/fr/" class="lang-btn">FR</a>
       <span class="lang-btn active">IT</span>
-      <a href="roestigraben.html" class="lang-btn">EN</a>
+      <a href="/roestigraben/" class="lang-btn">EN</a>
     </div>
   </div>
-  <a href="index.html" class="swiss-cross" aria-label="Torna alla home page"></a>
+  <a href="/index.html" class="swiss-cross" aria-label="Torna alla home page"></a>
 
   <section class="section section--full" id="hero" data-bg="#DA291C">
     <h1 class="fade-element">Oltre<br>il<br>Röstigraben</h1>
@@ -40,7 +40,7 @@
       <p>Dalle roccaforti monolingui alle comunità multiculturali: scoprite dove la Svizzera parla con una sola voce e dove convivono molte lingue.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Mappa sociale" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Mappa sociale" class="map">
     </div>
   </section>
 
@@ -50,7 +50,7 @@
       <p>Cosa possono rivelare i cognomi sull’identità linguistica? Confrontiamo l’origine dei nomi più diffusi con le lingue parlate a livello locale.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Mappa culturale" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Mappa culturale" class="map">
     </div>
   </section>
 
@@ -60,7 +60,7 @@
       <p>Migrazioni e demografia modificano continuamente l’equilibrio linguistico. Seguite l’ascesa e il declino di tedesco, francese, italiano e altre lingue negli ultimi decenni.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Mappa temporale" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Mappa temporale" class="map">
     </div>
   </section>
 
@@ -70,11 +70,11 @@
       <p>Il multilinguismo alimenta la prosperità? Esplorate i legami tra varietà linguistica e reddito, occupazione e abitazioni nelle diverse regioni.</p>
     </div>
     <div class="map-container">
-      <img src="static/images/roestigraben/switzerland.svg" alt="Mappa economica" class="map">
+      <img src="/static/images/roestigraben/switzerland.svg" alt="Mappa economica" class="map">
     </div>
   </section>
 
-  <script src="static/js/roestigraben.js"></script>
+  <script src="/static/js/roestigraben.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Move Swiss hospital and Röstigraben pages into dedicated folders with language-specific subdirectories.
- Update navigation links across site to point to new paths.
- Use root-relative asset paths in localized pages.

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c8256abf80832d8950bc0c542f7909