### PR TITLE
Update BSc Thesis page for SurgiToolVision

### DIFF
--- a/projects/bsc-thesis/index.html
+++ b/projects/bsc-thesis/index.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
 <script>(function(){var base="/";var marker="/joonhaim.github.io/";var idx=location.pathname.indexOf(marker);if(idx!==-1){var rootPath=location.pathname.slice(0,idx+marker.length);base=location.protocol==="file:"?"file://"+rootPath:location.origin+rootPath;}document.write('<base href="'+base.replace(/"/g,'&quot;')+'">');})();</script>
-  <title>Design and Evaluation of an Active Vision System for Surgical Tool Recognition</title>
-  <meta name="description" content="BSc thesis page for a project on active vision methods for surgical tool recognition.">
+  <title>SurgiToolVision | BSc Thesis</title>
+  <meta name="description" content="BSc thesis page for SurgiToolVision, an active vision system for surgical instrument and state recognition.">
   <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
@@ -21,10 +21,35 @@
 
     <main class="content">
       <section class="project-intro">
-        <h1>BSc Thesis</h1>
+        <h1>BSc Thesis: SurgiToolVision</h1>
         <p>
-          Title: Design and Evaluation of an Active Vision System for Surgical Tool Recognition
-          <br>Page under construction.
+          <strong>SurgiToolVision</strong> focuses on designing and evaluating a computer vision system that can automatically
+          recognize surgical instruments and their state. The core system uses YOLO-based object detection models to identify
+          handheld tools such as scalpels, clamps, shears, and needle holders from images or live camera feeds.
+        </p>
+        <p>
+          Beyond tool detection, the project includes state analysis for hinged instruments (for example, open vs. closed clamp
+          or needle holder) and integrates the full machine learning pipeline: dataset preparation, model training, evaluation,
+          and a user interface for image and live-camera inference.
+        </p>
+      </section>
+
+      <section>
+        <h2>Research Focus</h2>
+        <p>
+          A key contribution is an <strong>active vision</strong> approach for surgical tool recognition. Instead of relying only on a
+          single static image, the system can leverage multiple viewpoints or request additional views when confidence is low.
+          This helps in challenging situations such as partial occlusion or ambiguous tool appearances from specific angles.
+        </p>
+      </section>
+
+      <section>
+        <h2>Evaluation Goals</h2>
+        <p>
+          Through experiments across models, viewpoints, and system configurations, SurgiToolVision evaluates how multi-view
+          information and instrument-state recognition improve reliability. The long-term motivation is to support future
+          operating room technologies, including surgical workflow analysis, robotic assistance, and automated instrument
+          tracking.
         </p>
       </section>
     </main>


### PR DESCRIPTION
### Motivation
- Replace the placeholder BSc thesis page with a named project page and a clear overview of SurgiToolVision, a BSc thesis on surgical instrument detection and state recognition using deep learning and active vision methods.
- Communicate the research focus on YOLO-based tool detection, instrument-state analysis, multi-view/active vision strategies, and evaluation goals that target real-world OR applications.

### Description
- Updated `projects/bsc-thesis/index.html` to change the HTML `<title>` and `meta` description and to update the main heading to "BSc Thesis: SurgiToolVision".
- Replaced the previous placeholder text with a substantive project overview describing YOLO-based tool detection, hinged-instrument state analysis, dataset preparation, model training and evaluation, and a user interface for image and live-camera inference.
- Added a "Research Focus" section that explains the active vision / multi-view approach and an "Evaluation Goals" section that outlines experiments and long-term motivations such as workflow analysis and instrument tracking.

### Testing
- Launched a local development server with `python3 scripts/dev_server.py` and confirmed the site served at `http://127.0.0.1:8000/`.
- Captured a full-page screenshot of `http://127.0.0.1:8000/projects/bsc-thesis/` using Playwright to validate the rendered content.
- Reviewed the updated markup in `projects/bsc-thesis/index.html` to confirm the content and structure changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ce86b278832d9406b0d9da38b5c1)