### PR TITLE
Projects: keep EduPace/BSc Thesis logo cards, remove duplicates, rename thesis tile

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -46,9 +46,9 @@
               class="project-logo"
               loading="lazy"
             >
-            <h3>BSc Thesis</h3>
+            <h3>BSc Thesis: Active Vision for Surgical Tool Recognition</h3>
             <p>
-              Design and Evaluation of an Active Vision System for Surgical Tool Recognition.
+              Thesis research on building and evaluating an active vision pipeline to identify surgical tools in challenging, dynamic operating-room footage.
             </p>
             <a href="projects/bsc-thesis/">View Project →</a>
           </article>
@@ -56,27 +56,6 @@
 
 
         <div class="project-grid">
-          <!-- EduPace -->
-          <article class="project">
-            <div class="project-details">
-              <h3>EduPace</h3>
-              <p>
-                Educational pacemaker training simulator blending ECG software, realistic pacing scenarios, and a tactile control unit for nurses and students.
-              </p>
-              <a href="projects/edupace/">View Project →</a>
-            </div>
-          </article>
-
-          <article class="project">
-            <div class="project-details">
-              <h3>BSc Thesis: Active Vision for Surgical Tool Recognition</h3>
-              <p>
-                Thesis project on designing and evaluating an active vision approach for recognizing surgical tools in dynamic and visually challenging operative scenes.
-              </p>
-              <a href="projects/bsc-thesis/">View Project →</a>
-            </div>
-          </article>
-
           <!-- Cognition & Computation -->
           <article class="project">
             <div class="project-details">


### PR DESCRIPTION
### Motivation
- Remove duplicated project tiles and keep the logo-based cards for clarity and a cleaner Projects page layout.
- Make the BSc thesis entry more descriptive and consistent by renaming the tile and updating its copy.

### Description
- Removed the duplicate plain `project-grid` entries for EduPace and the BSc thesis, leaving only the logo-based cards in the academic section of `projects/index.html`.
- Updated the BSc thesis card title to `BSc Thesis: Active Vision for Surgical Tool Recognition` and revised its description copy to reflect the active vision pipeline focus.
- Kept the EduPace logo card and its existing copy unchanged while deleting the redundant EduPace project tile.

### Testing
- Started the local dev server with `python3 scripts/dev_server.py` and verified the site served successfully (server started and reachable).
- Loaded `/projects/` via an automated Playwright script and saved a full-page screenshot to confirm the visual layout changes (artifact created successfully).
- Inspected the modified `projects/index.html` fragment with `nl -ba projects/index.html | sed -n '30,130p'` to validate the removed/updated HTML blocks (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d1238250832d97855f1f49bf480d)