### PR TITLE
Add Playwright E2E tests, config, and GitHub Actions workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,38 @@
+name: Playwright Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 /.idea
+/node_modules
+/test-results

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "joonhaim-github-io",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "joonhaim-github-io",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.55.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "dev": "python3 scripts/dev_server.py"
+    "dev": "python3 scripts/dev_server.py",
+    "test:e2e": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.55.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:8000',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'python3 -m http.server 8000',
+    url: 'http://127.0.0.1:8000',
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/tests/site.spec.ts
+++ b/tests/site.spec.ts
@@ -18,12 +18,14 @@ test.describe('site smoke tests', () => {
   });
 
   test('contact page should expose key contact channels', async ({ page }) => {
-    await page.goto('/contact/');
-    await expect(page.getByRole('heading', { name: 'Contact' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Email' })).toHaveAttribute('href', /mailto:/);
-    await expect(page.getByRole('link', { name: 'GitHub' })).toHaveAttribute('href', /github\.com/);
-    await expect(page.getByRole('button', { name: 'Send Message' })).toBeVisible();
-  });
+  await page.goto('/contact/');
+  const contact = page.locator('#contact');
+
+  await expect(contact.getByRole('heading', { name: 'Contact' })).toBeVisible();
+  await expect(contact.getByRole('link', { name: 'Email' })).toHaveAttribute('href', /mailto:/);
+  await expect(contact.getByRole('link', { name: 'GitHub' })).toHaveAttribute('href', /github\.com/);
+  await expect(contact.getByRole('button', { name: 'Send Message' })).toBeVisible();
+});
 
   test('primary home navigation links should not 404', async ({ page }) => {
     await page.goto('/');

--- a/tests/site.spec.ts
+++ b/tests/site.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+const routes = ['/', '/contact/', '/404.html', '/playground/bezier/'];
+
+test.describe('site smoke tests', () => {
+  for (const route of routes) {
+    test(`GET ${route} should load without hard errors`, async ({ page }) => {
+      const response = await page.goto(route, { waitUntil: 'domcontentloaded' });
+      expect(response).not.toBeNull();
+      expect(response?.status()).toBeLessThan(400);
+    });
+  }
+
+  test('home page should render welcome heading and projects section', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Welcome!' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Featured Projects' })).toBeVisible();
+  });
+
+  test('contact page should expose key contact channels', async ({ page }) => {
+    await page.goto('/contact/');
+    await expect(page.getByRole('heading', { name: 'Contact' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Email' })).toHaveAttribute('href', /mailto:/);
+    await expect(page.getByRole('link', { name: 'GitHub' })).toHaveAttribute('href', /github\.com/);
+    await expect(page.getByRole('button', { name: 'Send Message' })).toBeVisible();
+  });
+
+  test('primary home navigation links should not 404', async ({ page }) => {
+    await page.goto('/');
+    const urls = await page.locator('main a[href]').evaluateAll((anchors) => {
+      const origin = window.location.origin;
+      return anchors
+        .map((a) => a.getAttribute('href'))
+        .filter((href): href is string => Boolean(href))
+        .filter((href) => href.startsWith('/') || !href.startsWith('http'))
+        .slice(0, 12)
+        .map((href) => new URL(href, origin).toString());
+    });
+
+    for (const url of urls) {
+      const response = await page.request.get(url);
+      expect(response.status(), `${url} should be reachable`).toBeLessThan(400);
+    }
+  });
+});


### PR DESCRIPTION
### Motivation

- Add end-to-end smoke tests to validate site pages and prevent regressions during CI.

### Description

- Add Playwright tests in `tests/site.spec.ts` that smoke-test key routes, navigation links, and core page elements.
- Add `playwright.config.ts` with test directory, timeout, reporter, webServer, and a Chromium project configuration.
- Update `package.json` to add the `test:e2e` script and `@playwright/test` devDependency.
- Add a GitHub Actions workflow `.github/workflows/playwright.yml` that installs Node, browsers, runs `npm run test:e2e`, and uploads the Playwright report.

### Testing

- The repository now has an automated CI job `Playwright Tests` which will run `npm ci` and `npm run test:e2e` on `push` and `pull_request` events.
- Playwright test cases exercise route loading, presence of key headings/links/buttons, and link reachability via `page.request.get`.
- No automated test runs have been executed in CI for this change yet.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ec5b9f08832d8675eccb90ca335e)