### PR TITLE
Add Plausible analytics injection to shared site script

### DIFF
--- a/static/js/shared/site.js
+++ b/static/js/shared/site.js
@@ -1,1 +1,15 @@
-// Shared page interactions are added here when needed.
+// Shared page interactions and global integrations.
+(function () {
+  const host = window.location.hostname;
+  const blockedHosts = new Set(["", "localhost", "127.0.0.1"]);
+
+  if (blockedHosts.has(host) || host.endsWith(".local")) {
+    return;
+  }
+
+  const script = document.createElement("script");
+  script.defer = true;
+  script.dataset.domain = "joonhaim.github.io";
+  script.src = "https://plausible.io/js/script.js";
+  document.head.appendChild(script);
+})();


### PR DESCRIPTION
### Motivation
- Integrate Plausible analytics on non-local hosts while preventing the script from loading during local development or `.local` environments.

### Description
- Replace the placeholder with an IIFE that inspects `window.location.hostname`, skips injection for hosts in a `blockedHosts` set and any host ending with `.local`, then creates a `script` element with `defer`, `data-domain="joonhaim.github.io"`, and `src="https://plausible.io/js/script.js"` and appends it to `document.head`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08efca9748832d9523dbd17405ea64)