### PR TITLE
Add repository pre-commit hook to run lint checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+
+npm run lint

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Then open: `http://127.0.0.1:8000`
 - `static/` – shared assets (CSS, JS, images)
 - `scripts/` – utility scripts
 
+## Git Hooks
+
+This repo uses a `pre-commit` hook that runs `npm run lint`.
+
+- Run `npm install` once to automatically configure Git to use repo hooks via `.githooks/`.
+- You can also configure it manually with `git config core.hooksPath .githooks`.
+
 ## Deployment
 
 This site is deployed with GitHub Pages.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint:js": "eslint \"**/*.js\"",
     "lint": "npm run format:check && npm run lint:html && npm run lint:js",
     "test:e2e": "playwright test",
-    "check": "npm run lint && npm run test:e2e"
+    "check": "npm run lint && npm run test:e2e",
+    "prepare": "git config core.hooksPath .githooks"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",


### PR DESCRIPTION
### Motivation

- Ensure code is linted on every commit by providing a repo-managed pre-commit hook that runs the existing lint pipeline.
- Make the hook easy to enable for contributors by configuring Git to use the repository `.githooks/` directory automatically via `package.json`.

### Description

- Add `.githooks/pre-commit` which runs `npm run lint` and is executable.
- Add a `prepare` script to `package.json` that runs `git config core.hooksPath .githooks` to configure repo hooks on install.
- Update `README.md` with a `Git Hooks` section documenting the hook behavior and how to enable it.

### Testing

- Ran `npm run lint`, and the `prettier --check .` step succeeded reporting all files are formatted correctly.
- The `lint:html` step failed in this environment because `htmlhint` is not available in local `node_modules`, causing the overall `npm run lint` to fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08fa8578b0832d8d6f24b2faff9f42)