### PR TITLE
Fix CH-IQI methodology table-of-contents links

### DIFF
--- a/projects/swiss-hospital-insights/methodology/index.html
+++ b/projects/swiss-hospital-insights/methodology/index.html
@@ -107,12 +107,12 @@
         <nav class="readme-toc" aria-label="Table of contents">
           <h3>Table of Contents</h3>
           <ol>
-            <li><a href="#purpose">Purpose</a></li>
-            <li><a href="#sources">Sources</a></li>
-            <li><a href="#database">Database</a></li>
-            <li><a href="#data-preparation">Data Preparation</a></li>
-            <li><a href="#indicators">Indicators and Calculations</a></li>
-            <li><a href="#limitations">Limitations</a></li>
+            <li><a href="projects/swiss-hospital-insights/methodology/#purpose">Purpose</a></li>
+            <li><a href="projects/swiss-hospital-insights/methodology/#sources">Sources</a></li>
+            <li><a href="projects/swiss-hospital-insights/methodology/#database">Database</a></li>
+            <li><a href="projects/swiss-hospital-insights/methodology/#data-preparation">Data Preparation</a></li>
+            <li><a href="projects/swiss-hospital-insights/methodology/#indicators">Indicators and Calculations</a></li>
+            <li><a href="projects/swiss-hospital-insights/methodology/#limitations">Limitations</a></li>
           </ol>
         </nav>
 


### PR DESCRIPTION
### Motivation
- The table-of-contents anchors on the CH-IQI methodology page used fragment-only links (e.g., `href="#purpose"`) which were resolved against the page's `<base href>` and redirected to the homepage instead of jumping to the intended in-page sections.

### Description
- Updated the six TOC anchors in `projects/swiss-hospital-insights/methodology/index.html` to use the full methodology path plus fragment (for example `projects/swiss-hospital-insights/methodology/#purpose`) so each link reliably targets its section.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08fd96445c832dbd4399a6527b99ed)