### PR TITLE
Add PR trigger and skip codex/* PRs in workflows

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,10 +4,13 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'codex/') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -13,6 +12,7 @@ permissions:
 jobs:
   check:
     name: Lint and test
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'codex/') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Update CI workflows to run on pull requests and avoid running jobs for PRs from branches prefixed with "codex/". .github/workflows/playwright.yml: add pull_request trigger (remove workflow_dispatch) and add a job-level if to skip test jobs for codex/* PRs. .github/workflows/quality.yml: remove workflow_dispatch and add the same job-level if to skip the lint/test job for codex/* PRs. This prevents CI from running on automated/internal codex branches while keeping existing behavior for main pushes.