### PR TITLE
Remove Plausible analytics integration

### DIFF
--- a/static/js/shared/site.js
+++ b/static/js/shared/site.js
@@ -1,15 +1,4 @@
 // Shared page interactions and global integrations.
 (function () {
-  const host = window.location.hostname;
-  const blockedHosts = new Set(["", "localhost", "127.0.0.1"]);
-
-  if (blockedHosts.has(host) || host.endsWith(".local")) {
-    return;
-  }
-
-  const script = document.createElement("script");
-  script.defer = true;
-  script.dataset.domain = "joonhaim.github.io";
-  script.src = "https://plausible.io/js/script.js";
-  document.head.appendChild(script);
+  // Intentionally left blank.
 })();


### PR DESCRIPTION
### Motivation
- Remove the Plausible analytics bootstrap and data collection logic so the site no longer injects `https://plausible.io/js/script.js` or performs host-based checks.

### Description
- Replaced the previous bootstrap in `static/js/shared/site.js` with an intentional no-op wrapper that preserves the shared script file but removes the Plausible script creation, domain dataset, and hostname blocking logic.

### Testing
- Ran repository search for `Plausible|plausible|plausible.io|data-domain` and verified the removed references in the modified file; the `static/js/shared/site.js` diff shows the Plausible injection removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a090f04a294832d95185fec9678448e)