### PR TITLE
Add Cloudflare Web Analytics snippet to public HTML pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -41,5 +41,12 @@
       </main>
       <div id="site-footer"></div>
     </div>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/about/index.html
+++ b/about/index.html
@@ -336,5 +336,12 @@
       </main>
       <div id="site-footer"></div>
     </div>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/ch_hospital.html
+++ b/ch_hospital.html
@@ -22,5 +22,12 @@
         >/projects/swiss-hospital-insights/</a
       >...
     </p>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/ch_hospital_de.html
+++ b/ch_hospital_de.html
@@ -25,5 +25,12 @@
         >/projects/swiss-hospital-insights/de/</a
       >...
     </p>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/ch_hospital_fr.html
+++ b/ch_hospital_fr.html
@@ -25,5 +25,12 @@
         >/projects/swiss-hospital-insights/fr/</a
       >...
     </p>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/ch_hospital_it.html
+++ b/ch_hospital_it.html
@@ -25,5 +25,12 @@
         >/projects/swiss-hospital-insights/it/</a
       >...
     </p>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/ch_hospital_methodology.html
+++ b/ch_hospital_methodology.html
@@ -25,5 +25,12 @@
         >/projects/swiss-hospital-insights/methodology/</a
       >...
     </p>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -82,5 +82,12 @@
       </main>
       <div id="site-footer"></div>
     </div>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/playground/bezier/index.html
+++ b/playground/bezier/index.html
@@ -928,5 +928,12 @@
         }, 50);
       })();
     </script>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/projects/bsc-thesis/index.html
+++ b/projects/bsc-thesis/index.html
@@ -82,5 +82,12 @@
 
       <div id="site-footer"></div>
     </div>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/projects/cognition/index.html
+++ b/projects/cognition/index.html
@@ -246,5 +246,12 @@
 
       <div id="site-footer"></div>
     </div>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/projects/easysave/index.html
+++ b/projects/easysave/index.html
@@ -232,5 +232,12 @@
         sections.forEach((sec) => observer.observe(sec));
       });
     </script>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/projects/edupace/index.html
+++ b/projects/edupace/index.html
@@ -1109,5 +1109,12 @@
 
       <div id="site-footer"></div>
     </div>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/projects/hai/index.html
+++ b/projects/hai/index.html
@@ -94,5 +94,12 @@
 
       <div id="site-footer"></div>
     </div>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -150,5 +150,12 @@
       <!-- Site Footer -->
       <div id="site-footer"></div>
     </div>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/projects/neural-networks/index.html
+++ b/projects/neural-networks/index.html
@@ -134,5 +134,12 @@
 
       <div id="site-footer"></div>
     </div>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/projects/reinforcement-learning/index.html
+++ b/projects/reinforcement-learning/index.html
@@ -244,5 +244,12 @@
 
       <div id="site-footer"></div>
     </div>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/projects/swiss-hospital-insights/de/index.html
+++ b/projects/swiss-hospital-insights/de/index.html
@@ -359,5 +359,12 @@
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="static/js/pages/ch_hospital.js"></script>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/projects/swiss-hospital-insights/fr/index.html
+++ b/projects/swiss-hospital-insights/fr/index.html
@@ -366,5 +366,12 @@
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="static/js/pages/ch_hospital.js"></script>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/projects/swiss-hospital-insights/index.html
+++ b/projects/swiss-hospital-insights/index.html
@@ -357,5 +357,12 @@
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="static/js/pages/ch_hospital.js"></script>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/projects/swiss-hospital-insights/it/index.html
+++ b/projects/swiss-hospital-insights/it/index.html
@@ -366,5 +366,12 @@
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="static/js/pages/ch_hospital.js"></script>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>

--- a/projects/swiss-hospital-insights/methodology/index.html
+++ b/projects/swiss-hospital-insights/methodology/index.html
@@ -361,5 +361,12 @@
         });
       });
     </script>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token":"e0b4bee33890495db57492041625ced9"}'
+    ></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Add Cloudflare Web Analytics to every real public HTML page so the site is tracked consistently with a single token, without duplicating snippets or touching non-public support files.

### Description
- Inserted the provided Cloudflare beacon snippet immediately before the closing `</body>` tag in 22 public HTML files: `404.html`, `about/index.html`, `ch_hospital.html`, `ch_hospital_de.html`, `ch_hospital_fr.html`, `ch_hospital_it.html`, `ch_hospital_methodology.html`, `contact/index.html`, `playground/bezier/index.html`, `projects/bsc-thesis/index.html`, `projects/cognition/index.html`, `projects/easysave/index.html`, `projects/edupace/index.html`, `projects/hai/index.html`, `projects/index.html`, `projects/neural-networks/index.html`, `projects/reinforcement-learning/index.html`, `projects/swiss-hospital-insights/index.html`, `projects/swiss-hospital-insights/de/index.html`, `projects/swiss-hospital-insights/fr/index.html`, `projects/swiss-hospital-insights/it/index.html`, and `projects/swiss-hospital-insights/methodology/index.html`.
- Left the existing snippet in `index.html` unchanged and did not add a duplicate there, and intentionally skipped non-public/support files `static/includes/header.html`, `static/includes/footer.html`, and `static/dev/edupace-test.html`.
- Used the same token everywhere (`e0b4bee33890495db57492041625ced9`) and avoided modifying unrelated content, layout, or lint configuration.

### Testing
- Ran `npm run format`, which succeeded and applied Prettier formatting to the modified files without errors.
- Ran `npm run lint`; `prettier --check` passed as part of the lint pipeline but the HTML lint step failed because the `htmlhint` executable is not available in the environment (`xargs: htmlhint: No such file or directory`), so full linting did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09148a9354832db9381745346a67c2)