### PR TITLE
Redesign BSc thesis page and add captioned visuals

### DIFF
--- a/projects/bsc-thesis/index.html
+++ b/projects/bsc-thesis/index.html
@@ -29,6 +29,7 @@
     <link rel="manifest" href="site.webmanifest" />
     <link rel="icon" href="favicon.ico" />
     <link rel="stylesheet" href="static/css/shared/site.css" />
+    <link rel="stylesheet" href="static/css/pages/bsc-thesis.css" />
     <script src="static/js/shared/site.js" defer></script>
     <script src="static/js/shared/includes.js" defer></script>
   </head>
@@ -37,7 +38,7 @@
       <div id="site-header"></div>
 
       <main class="content">
-        <section class="project-intro">
+        <section class="project-intro thesis-hero">
           <h1>BSc Thesis: SurgiToolVision</h1>
           <p>
             <strong>SurgiToolVision</strong> focuses on designing and evaluating
@@ -55,6 +56,80 @@
           </p>
         </section>
 
+        <section>
+          <h2>System Highlights</h2>
+          <div class="thesis-grid">
+            <article class="metric-card">
+              <h3>Detection Backbone</h3>
+              <p>
+                YOLO-based detector for real-time surgical instrument
+                localization and classification.
+              </p>
+            </article>
+            <article class="metric-card">
+              <h3>State Recognition</h3>
+              <p>
+                Dedicated logic for detecting open/closed states of hinged
+                instruments (e.g., clamps).
+              </p>
+            </article>
+            <article class="metric-card">
+              <h3>Active Vision</h3>
+              <p>
+                Adaptive multi-view strategy that requests additional angles
+                when confidence is low.
+              </p>
+            </article>
+            <article class="metric-card">
+              <h3>Clinical Motivation</h3>
+              <p>
+                Designed to support future surgical workflow analysis and
+                assistive OR technologies.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2>Project Visuals</h2>
+          <div class="figure-gallery">
+            <figure class="figure-card">
+              <img
+                src="static/images/bsc-thesis/pipeline.svg"
+                alt="Diagram of dataset, training, inference, and evaluation stages in SurgiToolVision"
+                loading="lazy"
+              />
+              <figcaption>
+                <strong>Figure 1.</strong> End-to-end workflow from dataset
+                preparation to model evaluation in the SurgiToolVision pipeline.
+              </figcaption>
+            </figure>
+            <figure class="figure-card">
+              <img
+                src="static/images/bsc-thesis/multiview.svg"
+                alt="Multi-view active vision concept showing multiple camera angles feeding one fused prediction"
+                loading="lazy"
+              />
+              <figcaption>
+                <strong>Figure 2.</strong> Active vision concept: combining
+                multiple viewpoints improves robustness under occlusions and
+                ambiguous angles.
+              </figcaption>
+            </figure>
+            <figure class="figure-card">
+              <img
+                src="static/images/bsc-thesis/interface.svg"
+                alt="Mockup of an inference interface with detected instruments and confidence scores"
+                loading="lazy"
+              />
+              <figcaption>
+                <strong>Figure 3.</strong> Interface mockup for
+                image/live-camera inference with confidence scores and
+                instrument-state output.
+              </figcaption>
+            </figure>
+          </div>
+        </section>
         <section>
           <h2>Research Focus</h2>
           <p>

--- a/static/css/pages/bsc-thesis.css
+++ b/static/css/pages/bsc-thesis.css
@@ -1,0 +1,56 @@
+.thesis-hero {
+  background: linear-gradient(135deg, #0f172a 0%, #1e3a8a 60%, #0ea5e9 100%);
+  color: #f8fafc;
+  padding: 2.25rem;
+  border-radius: 1rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.24);
+}
+
+.thesis-hero p {
+  color: #e2e8f0;
+}
+
+.thesis-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.metric-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.8rem;
+  padding: 1rem;
+}
+
+.metric-card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.figure-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.figure-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.9rem;
+  overflow: hidden;
+  background: #fff;
+}
+
+.figure-card img {
+  width: 100%;
+  aspect-ratio: 16/10;
+  object-fit: cover;
+  display: block;
+}
+
+.figure-card figcaption {
+  padding: 0.8rem 1rem 1rem;
+  font-size: 0.95rem;
+  color: #334155;
+}

--- a/static/images/bsc-thesis/interface.svg
+++ b/static/images/bsc-thesis/interface.svg
@@ -1,0 +1,12 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 700'>
+  <rect width='1200' height='700' fill='#eef2ff'/>
+  <rect x='120' y='100' width='960' height='500' rx='28' fill='#ffffff' stroke='#cbd5e1' stroke-width='4'/>
+  <rect x='170' y='160' width='600' height='360' rx='16' fill='#e2e8f0'/>
+  <rect x='810' y='160' width='220' height='100' rx='14' fill='#d1fae5'/>
+  <rect x='810' y='280' width='220' height='100' rx='14' fill='#bfdbfe'/>
+  <rect x='810' y='400' width='220' height='100' rx='14' fill='#fecaca'/>
+  <text x='850' y='220' font-size='24' font-family='Arial' fill='#0f172a'>Scalpel 0.96</text>
+  <text x='850' y='340' font-size='24' font-family='Arial' fill='#0f172a'>Clamp 0.91</text>
+  <text x='850' y='460' font-size='24' font-family='Arial' fill='#0f172a'>State: Open</text>
+  <text x='600' y='70' text-anchor='middle' font-size='40' font-family='Arial' fill='#0f172a'>Inference Interface Mockup</text>
+</svg>

--- a/static/images/bsc-thesis/multiview.svg
+++ b/static/images/bsc-thesis/multiview.svg
@@ -1,0 +1,14 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 700'>
+  <rect width='1200' height='700' fill='#f8fafc'/>
+  <text x='600' y='80' text-anchor='middle' font-size='40' font-family='Arial' fill='#0f172a'>Active Multi-view Recognition</text>
+  <g font-family='Arial' font-size='22' fill='#0f172a'>
+    <rect x='120' y='160' width='280' height='200' rx='18' fill='#e2e8f0'/>
+    <rect x='460' y='160' width='280' height='200' rx='18' fill='#dbeafe'/>
+    <rect x='800' y='160' width='280' height='200' rx='18' fill='#e0e7ff'/>
+    <text x='190' y='270'>Viewpoint A</text><text x='530' y='270'>Viewpoint B</text><text x='870' y='270'>Viewpoint C</text>
+    <circle cx='600' cy='500' r='120' fill='#ccfbf1'/><text x='535' y='510'>Fused</text><text x='520' y='540'>Prediction</text>
+  </g>
+  <g stroke='#334155' stroke-width='5' fill='none'>
+    <path d='M260 360 L520 430'/><path d='M600 360 L600 380'/><path d='M940 360 L680 430'/>
+  </g>
+</svg>

--- a/static/images/bsc-thesis/pipeline.svg
+++ b/static/images/bsc-thesis/pipeline.svg
@@ -1,0 +1,18 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 700'>
+  <defs>
+    <linearGradient id='bg' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#ecfeff'/><stop offset='100%' stop-color='#f8fafc'/>
+    </linearGradient>
+  </defs>
+  <rect width='1200' height='700' fill='url(#bg)'/>
+  <text x='600' y='80' text-anchor='middle' font-size='42' font-family='Arial' fill='#0f172a'>SurgiToolVision Pipeline</text>
+  <g font-family='Arial' fill='#0f172a' font-size='24' text-anchor='middle'>
+    <rect x='80' y='220' width='220' height='160' rx='24' fill='#cffafe'/><text x='190' y='300'>Dataset</text>
+    <rect x='360' y='220' width='220' height='160' rx='24' fill='#bae6fd'/><text x='470' y='300'>Training</text>
+    <rect x='640' y='220' width='220' height='160' rx='24' fill='#bfdbfe'/><text x='750' y='300'>Inference</text>
+    <rect x='920' y='220' width='220' height='160' rx='24' fill='#ddd6fe'/><text x='1030' y='300'>Evaluation</text>
+  </g>
+  <g stroke='#0f172a' stroke-width='7' fill='none' stroke-linecap='round'>
+    <path d='M300 300h50'/><path d='M580 300h50'/><path d='M860 300h50'/>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Improve the readability and visual hierarchy of the BSc thesis page so readers can quickly scan the contribution and workflow. 
- Surface key system components and visuals to better communicate the pipeline, multi-view idea, and interface mockup. 
- Keep the changes local to the thesis page so other site pages and shared styles remain unaffected.

### Description
- Added a page-specific stylesheet `static/css/pages/bsc-thesis.css` and wired it into `projects/bsc-thesis/index.html` to provide a hero, card and figure layout. 
- Converted the intro into a styled hero (`.project-intro.thesis-hero`) and added a new `System Highlights` grid with four `metric-card` entries summarizing core contributions. 
- Introduced a `Project Visuals` section with three captioned figures using local SVG assets placed under `static/images/bsc-thesis/` and markup that includes `alt` text and `loading="lazy"`. 
- Implemented responsive layout classes (`.thesis-grid`, `.figure-gallery`, `.figure-card`) and image rules to ensure the gallery adapts across viewports.

### Testing
- Ran `npx prettier --write projects/bsc-thesis/index.html static/css/pages/bsc-thesis.css` which formatted the changed files successfully. 
- Ran `npx prettier --check projects/bsc-thesis/index.html static/css/pages/bsc-thesis.css` which passed the style check. 
- Attempted `npx htmlhint projects/bsc-thesis/index.html` but this was blocked by registry access (npm 403) in the current environment. 
- Attempted Playwright screenshot generation but it failed because Playwright browser binaries are not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091b398428832d8f9535aa0d05ad6c)