### PR TITLE
Improve BSc Thesis page design and layout

### DIFF
--- a/projects/bsc-thesis/index.html
+++ b/projects/bsc-thesis/index.html
@@ -31,6 +31,7 @@
     <link rel="manifest" href="site.webmanifest" />
     <link rel="icon" href="favicon.ico" />
     <link rel="stylesheet" href="static/css/shared/site.css" />
+    <link rel="stylesheet" href="static/css/pages/bsc-thesis.css" />
     <script src="static/js/shared/site.js" defer></script>
     <script src="static/js/shared/includes.js" defer></script>
   </head>
@@ -38,83 +39,130 @@
     <div class="container">
       <div id="site-header"></div>
 
-      <main class="content">
-        <section class="project-intro">
-          <h1>Active Vision System for Surgical Instrument Recognition</h1>
-
-          <p>
-            For my Bachelor Thesis in Data Science &amp; AI at Leiden
-            University, I designed and evaluated an active vision system for
-            recognizing handheld surgical instruments and their hinge state. The
-            project focused on a controlled medical computer vision setting
-            where the system had to identify both the instrument category and,
-            for hinged tools, whether the instrument was open or closed.
-          </p>
-
-          <p>
-            The system was evaluated on five categories of general surgical
-            instruments: clamps, needle holders, scalpels, shears, and tweezers.
-            I created a dedicated image dataset of
-            <strong>2,520 images</strong>, collected under controlled variations
-            in viewpoint, background, lighting, and hinge state. The dataset
-            included top-down, oblique, and close-up views, as well as different
-            surgical-style backgrounds such as a stainless steel tray and
-            colored drapes.
-          </p>
-
-          <p>
-            The recognition pipeline combined a YOLO-based object detector with
-            a separate hinge-state classifier. The detector first localized and
-            classified the instrument. If the detected instrument belonged to a
-            hinged category, the detected region was cropped and passed to a
-            binary classifier that predicted whether the instrument was open or
-            closed.
-          </p>
-
-          <p>
-            A key part of the project was the evaluation of active multi-view
-            acquisition. Instead of always using all available viewpoints, the
-            system could request an additional view only when the current
-            prediction was uncertain. This made it possible to study the
-            trade-off between recognition accuracy and the number of views
-            required.
-          </p>
-
-          <p>
-            The best vision-only models achieved strong performance in the
-            controlled setting, with the best detector reaching
-            <strong>98.2% mAP@50:95</strong> and the best hinge-state classifier
-            reaching <strong>98.1% accuracy</strong>. The experiments showed
-            that viewpoint mattered differently depending on the task: close-up
-            views were most useful for identifying the instrument category,
-            while top-down views were more effective for recognizing hinge
-            state. I also compared the trained vision-only pipeline with several
-            zero-shot vision-language models, which performed substantially
-            worse, especially on the hinge-state classification task.
-          </p>
-
-          <p>
-            This project gave me practical experience with end-to-end computer
-            vision system design, including dataset collection, annotation,
-            model training, evaluation, active perception, and failure-case
-            analysis in a medical AI context.
-          </p>
+      <main class="content bsc-thesis-page">
+        <section class="bsc-hero">
+          <div>
+            <p class="eyebrow">Leiden University · BSc Data Science &amp; AI</p>
+            <h1>Active Vision System for Surgical Instrument Recognition</h1>
+            <p class="lead">
+              This thesis explores how an active multi-view computer vision
+              pipeline can improve surgical instrument recognition and
+              hinge-state estimation while minimizing unnecessary camera views.
+            </p>
+            <div class="bsc-actions">
+              <a class="bsc-button primary" href="static/pdf/hai/HAI_report.pdf"
+                >Read full thesis report</a
+              >
+              <a class="bsc-button secondary" href="#results"
+                >Jump to key results</a
+              >
+            </div>
+          </div>
+          <figure class="hero-card">
+            <img
+              src="static/images/bsc-thesis/unified_pipeline.drawio.png"
+              alt="Unified thesis pipeline diagram"
+            />
+            <figcaption>
+              Unified recognition pipeline: detector, crop extraction, and
+              hinge-state classification.
+            </figcaption>
+          </figure>
         </section>
 
-        <section>
-          <h2>Technologies Used</h2>
-          <p>
-            Python, PyTorch, Ultralytics YOLO, EfficientNet, ResNet, Label
-            Studio, Grad-CAM, LaTeX
-          </p>
+        <section class="kpi-grid" id="results">
+          <article class="kpi">
+            <strong>2,520</strong><span>Annotated dataset images</span>
+          </article>
+          <article class="kpi">
+            <strong>5</strong><span>Instrument categories</span>
+          </article>
+          <article class="kpi">
+            <strong>98.2%</strong><span>Best detector mAP@50:95</span>
+          </article>
+          <article class="kpi">
+            <strong>98.1%</strong><span>Best hinge-state accuracy</span>
+          </article>
         </section>
 
-        <section>
-          <h2>Topics</h2>
-          <p>
-            Computer Vision, Medical AI, Surgical Instrument Recognition, Active
-            Vision, Multi-View Perception, Vision-Language Models
-          </p>
+        <section class="section-card split-grid">
+          <div>
+            <h2>Project overview</h2>
+            <p>
+              The thesis was developed around a controlled medical CV setup with
+              five general-surgery categories: clamps, needle holders, scalpels,
+              shears, and tweezers. Each sample varied by viewpoint, background
+              style, lighting, and hinge state.
+            </p>
+            <p>
+              Instead of always requiring all available viewpoints, the system
+              can request extra views only when confidence is low. This supports
+              a practical trade-off between recognition accuracy and capture
+              cost.
+            </p>
+          </div>
+          <div>
+            <h2>Method in brief</h2>
+            <p>
+              A YOLO detector localizes and classifies instruments. For hinged
+              categories, the detected crop is forwarded to a dedicated binary
+              classifier predicting open vs. closed state.
+            </p>
+            <p>
+              Additional analysis compared this vision-only pipeline with
+              zero-shot vision-language baselines, which performed notably worse
+              in this domain.
+            </p>
+          </div>
+        </section>
+
+        <section class="section-card">
+          <h2>Visual highlights</h2>
+          <div class="image-grid">
+            <figure>
+              <img
+                src="static/images/bsc-thesis/dataset_annotation.png"
+                alt="Dataset annotation example"
+              />
+              <figcaption>
+                Annotation workflow used to prepare robust detection data.
+              </figcaption>
+            </figure>
+            <figure>
+              <img
+                src="static/images/bsc-thesis/mult_image_crop.jpg"
+                alt="Multi-view image crop examples"
+              />
+              <figcaption>
+                Multi-view crops capture top-down, oblique, and close-up cues.
+              </figcaption>
+            </figure>
+            <figure>
+              <img
+                src="static/images/bsc-thesis/detect_test_confusion_matrices.png"
+                alt="Test confusion matrices"
+              />
+              <figcaption>
+                Confusion-matrix diagnostics for detector class behavior.
+              </figcaption>
+            </figure>
+          </div>
+        </section>
+
+        <section class="section-card">
+          <h2>Technologies and topics</h2>
+          <ul class="tag-list">
+            <li>Python</li>
+            <li>PyTorch</li>
+            <li>Ultralytics YOLO</li>
+            <li>EfficientNet</li>
+            <li>ResNet</li>
+            <li>Label Studio</li>
+            <li>Grad-CAM</li>
+            <li>Medical AI</li>
+            <li>Active Vision</li>
+            <li>Multi-View Perception</li>
+          </ul>
         </section>
       </main>
 

--- a/static/css/pages/bsc-thesis.css
+++ b/static/css/pages/bsc-thesis.css
@@ -1,0 +1,159 @@
+.bsc-thesis-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.bsc-hero {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 2rem;
+  padding: 2rem;
+  border-radius: 20px;
+  background: linear-gradient(120deg, #0f172a 0%, #1e293b 45%, #334155 100%);
+  color: #f8fafc;
+  box-shadow: 0 16px 44px rgba(15, 23, 42, 0.25);
+}
+
+.bsc-hero h1 {
+  color: #fff;
+  margin-bottom: 1rem;
+}
+.bsc-hero .eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+  color: #cbd5e1;
+}
+.bsc-hero .lead {
+  color: #e2e8f0;
+}
+
+.bsc-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.bsc-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1rem;
+  border-radius: 999px;
+  font-weight: 700;
+  text-decoration: none;
+}
+.bsc-button.primary {
+  background: #38bdf8;
+  color: #082f49;
+}
+.bsc-button.secondary {
+  border: 1px solid #94a3b8;
+  color: #e2e8f0;
+}
+
+.hero-card {
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(203, 213, 225, 0.24);
+  border-radius: 16px;
+  overflow: hidden;
+}
+.hero-card img {
+  width: 100%;
+  display: block;
+}
+.hero-card figcaption {
+  padding: 0.85rem 1rem;
+  font-size: 0.9rem;
+  color: #cbd5e1;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.kpi {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 1rem;
+}
+.kpi strong {
+  display: block;
+  font-size: 1.6rem;
+  color: #0f172a;
+}
+.kpi span {
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.section-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 1.5rem;
+}
+
+.split-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.2rem;
+}
+
+.image-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+.image-grid figure {
+  margin: 0;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+}
+.image-grid img {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  display: block;
+}
+.image-grid figcaption {
+  padding: 0.75rem;
+  font-size: 0.9rem;
+  color: #334155;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  padding: 0;
+  margin: 0.5rem 0 0;
+  list-style: none;
+}
+.tag-list li {
+  background: #e0f2fe;
+  color: #0c4a6e;
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+@media (max-width: 980px) {
+  .bsc-hero,
+  .kpi-grid,
+  .split-grid,
+  .image-grid {
+    grid-template-columns: 1fr;
+  }
+  .image-grid img {
+    height: auto;
+  }
+}


### PR DESCRIPTION
### Motivation
- Make the BSc thesis page more scannable and visually engaging by introducing a modern hero and sectioned layout. 
- Surface key project outcomes immediately with clear KPI cards and CTAs to encourage readers to open the full report. 
- Showcase existing thesis artifacts and figures on the page to better illustrate methodology and results.

### Description
- Rewrote the page structure in `projects/bsc-thesis/index.html` to a section-based layout including a hero, KPI grid, overview/method split, visual highlights gallery, and technologies/tags section. 
- Added a page-specific stylesheet at `static/css/pages/bsc-thesis.css` that provides hero styling, card components, KPI grid, image gallery, tag pills, and responsive grid rules. 
- Integrated existing thesis images from `static/images/bsc-thesis/` into a visual highlights gallery and included a pipeline diagram as the hero visual. 
- Added prominent CTA buttons linking to the thesis PDF (`static/pdf/hai/HAI_report.pdf`) and an anchor to jump to key results.

### Testing
- Ran code formatting with `npx prettier --write projects/bsc-thesis/index.html static/css/pages/bsc-thesis.css`, which completed successfully. 
- Attempted HTML lint with `npm run lint:html -- projects/bsc-thesis/index.html`, which failed in this environment because `htmlhint` is not installed. 
- Attempted an automated page screenshot with Playwright via `npx playwright screenshot ...`, which failed because Playwright browser binaries are not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091caa4c70832d8782636324ef4f7a)