### PR TITLE
Pre-commit: run formatting/linting only on staged files and update docs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,11 +1,21 @@
 #!/usr/bin/env sh
 set -eu
 
-echo "Running Prettier..."
-npm run format
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR)
+
+if [ -z "$STAGED_FILES" ]; then
+  echo "No staged files to check."
+  exit 0
+fi
+
+echo "Running Prettier on staged files..."
+printf '%s\n' "$STAGED_FILES" | rg '\.(js|css|md|json|ya?ml|html)$' | xargs -r npx prettier --write
+
+echo "Running ESLint on staged JS files..."
+printf '%s\n' "$STAGED_FILES" | rg '\.js$' | xargs -r npx eslint --fix
+
+echo "Running HTMLHint on staged HTML files..."
+printf '%s\n' "$STAGED_FILES" | rg '\.html$' | xargs -r npx htmlhint
 
 echo "Re-staging formatted files..."
-git diff --name-only -z --diff-filter=ACMR | xargs -0 git add
-
-echo "Running lint..."
-npm run lint
+printf '%s\n' "$STAGED_FILES" | xargs -r git add

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ Then open: `http://127.0.0.1:8000`
 
 ## Git Hooks
 
-This repo uses a `pre-commit` hook that runs `npm run lint`.
+This repo uses a custom `pre-commit` hook for staged-file checks.
 
+- On each commit, only **staged files** are formatted with Prettier and checked with file-scoped linters.
+- Full-repo checks (including `prettier --check` for non-staged files) run in CI.
 - Run `npm install` once to automatically configure Git to use repo hooks via `.githooks/`.
 - You can also configure it manually with `git config core.hooksPath .githooks`.
 


### PR DESCRIPTION
### Motivation
- Avoid slow full-repo formatting/linting on every local commit by limiting work to staged files.
- Preserve full-repo verification in CI (including `prettier --check`) so repository-wide issues are still caught on push/PR.

### Description
- Replace `.githooks/pre-commit` to collect staged files and run `prettier --write` on supported staged files, `eslint --fix` on staged `.js` files, `htmlhint` on staged `.html` files, and re-stage any modified files.
- Update `README.md` Git Hooks section to document the new staged-file behavior and note that full-repo checks run in CI.
- Keep CI and `npm run lint` behavior unchanged so full-repo checks remain part of the CI `check` job.

### Testing
- Ran `npm run lint`, which executed `prettier --check` (reported: "All matched files use Prettier code style!") and `htmlhint` (no errors), and completed with exit code 0.
- Ran `eslint` as part of the lint run which finished with 2 warnings and no errors (process succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c754adf24832dae2aa23f421d742d)