### PR TITLE
Expand Playwright smoke tests for shared includes, assets, nested routes, and links

### DIFF
--- a/tests/site.spec.ts
+++ b/tests/site.spec.ts
@@ -2,6 +2,27 @@ import { test, expect } from "@playwright/test";
 
 const routes = ["/", "/contact/", "/404.html", "/playground/bezier/"];
 
+const nestedProjectRoutes = [
+  "/projects/edupace/",
+  "/projects/reinforcement-learning/",
+  "/projects/swiss-hospital-insights/methodology/",
+  "/projects/swiss-hospital-insights/de/",
+];
+
+const staticAssets = [
+  "/static/css/shared/site.css",
+  "/static/js/shared/site.js",
+  "/static/js/shared/includes.js",
+];
+
+const brokenLinkScanPages = [
+  "/",
+  "/projects/",
+  "/contact/",
+  "/projects/swiss-hospital-insights/",
+  "/projects/edupace/",
+];
+
 test.describe("site smoke tests", () => {
   for (const route of routes) {
     test(`GET ${route} should load without hard errors`, async ({ page }) => {
@@ -21,6 +42,24 @@ test.describe("site smoke tests", () => {
     await expect(
       page.getByRole("heading", { name: "Featured Projects" }),
     ).toBeVisible();
+  });
+
+  test("shared includes should load full site header/footer (not fallback shells)", async ({
+    page,
+  }) => {
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    const header = page.locator("#site-header");
+    const footer = page.locator("#site-footer");
+
+    await expect(header.locator("header.site-header")).toBeVisible();
+    await expect(footer.locator("footer.site-footer")).toBeVisible();
+    await expect(header.locator("[data-fallback='true']")).toHaveCount(0);
+    await expect(footer.locator("[data-fallback='true']")).toHaveCount(0);
+    await expect(header.getByRole("link", { name: "Projects" })).toBeVisible();
+    await expect(
+      footer.getByRole("link", { name: "LinkedIn" }),
+    ).toHaveAttribute("href", /linkedin\.com/i);
   });
 
   test("contact page should expose key contact channels", async ({ page }) => {
@@ -69,21 +108,53 @@ test.describe("site smoke tests", () => {
     await expect(page.getByRole("heading", { name: "404" })).toBeVisible();
   });
 
-  test("primary home navigation links should not 404", async ({ page }) => {
-    await page.goto("/");
-    const urls = await page.locator("main a[href]").evaluateAll((anchors) => {
-      const origin = window.location.origin;
-      return anchors
-        .map((a) => a.getAttribute("href"))
-        .filter((href): href is string => Boolean(href))
-        .filter((href) => href.startsWith("/") || !href.startsWith("http"))
-        .slice(0, 12)
-        .map((href) => new URL(href, origin).toString());
-    });
+  test("key static assets should return HTTP 200", async ({ request }) => {
+    for (const assetPath of staticAssets) {
+      const response = await request.get(assetPath);
+      expect(response.status(), `${assetPath} should be served`).toBe(200);
+    }
+  });
 
-    for (const url of urls) {
-      const response = await page.request.get(url);
-      expect(response.status(), `${url} should be reachable`).toBeLessThan(400);
+  test("representative nested project routes should load", async ({ page }) => {
+    for (const route of nestedProjectRoutes) {
+      const response = await page.goto(route, { waitUntil: "domcontentloaded" });
+      expect(response, `${route} should return a response`).not.toBeNull();
+      expect(response?.status(), `${route} should be reachable`).toBeLessThan(400);
+      await expect(page).toHaveURL(new RegExp(`${route}$`));
+    }
+  });
+
+  test("internal links on key pages should not be broken", async ({ page, request }) => {
+    const visited = new Set<string>();
+
+    for (const route of brokenLinkScanPages) {
+      await page.goto(route, { waitUntil: "domcontentloaded" });
+      const urls = await page.locator("a[href]").evaluateAll((anchors) => {
+        const origin = window.location.origin;
+
+        return anchors
+          .map((a) => a.getAttribute("href")?.trim() ?? "")
+          .filter((href) => Boolean(href))
+          .filter(
+            (href) =>
+              href.startsWith("/") ||
+              href.startsWith("./") ||
+              href.startsWith("../") ||
+              href.startsWith("#"),
+          )
+          .map((href) => new URL(href, origin).toString());
+      });
+
+      for (const url of urls) {
+        const normalized = url.split("#")[0] || url;
+        if (visited.has(normalized)) continue;
+        visited.add(normalized);
+
+        const response = await request.get(normalized);
+        expect(response.status(), `${normalized} should be reachable`).toBeLessThan(
+          400,
+        );
+      }
     }
   });
 });

--- a/tests/site.spec.ts
+++ b/tests/site.spec.ts
@@ -57,9 +57,7 @@ test.describe("site smoke tests", () => {
     await expect(header.locator("[data-fallback='true']")).toHaveCount(0);
     await expect(footer.locator("[data-fallback='true']")).toHaveCount(0);
     await expect(header.getByRole("link", { name: "Projects" })).toBeVisible();
-    await expect(
-      footer.getByRole("link", { name: "LinkedIn" }),
-    ).toHaveAttribute("href", /linkedin\.com/i);
+    await expect(footer).toContainText(/Adrien\s+Joon[-‑ ]?Ha\s+Im/i);
   });
 
   test("contact page should expose key contact channels", async ({ page }) => {


### PR DESCRIPTION
### Motivation
- Improve confidence that the rendered site includes the real shared header/footer markup rather than client-side fallback shells.  
- Verify that key static CSS/JS assets are actually served by the dev server.  
- Cover representative nested `projects/*/` pages (including localized and methodology pages) to catch routing regressions.  
- Broaden broken-link detection from a small homepage sample to a deduplicated scan of internal anchors on multiple key pages.

### Description
- Expanded `tests/site.spec.ts` with new route lists: `nestedProjectRoutes`, `staticAssets`, and `brokenLinkScanPages`.  
- Added a test asserting `#site-header` and `#site-footer` render full include markup and do not expose fallback shells (`[data-fallback='true']`).  
- Added a static asset test that requests `static/css/shared/site.css`, `static/js/shared/site.js`, and `static/js/shared/includes.js` and expects HTTP 200.  
- Replaced the limited “first 12 home links” check with a broader internal-anchor scan across `brokenLinkScanPages` that normalizes and deduplicates URLs before requesting them.

### Testing
- Ran `npm run test:e2e -- -g "key static assets should return HTTP 200"` and the static asset test passed ✅.  
- Ran the full suite with `npm run test:e2e -- tests/site.spec.ts` which failed in this environment because Playwright’s Chromium binary is not installed (Playwright requests `npx playwright install`) ⚠️.  
- The change to `tests/site.spec.ts` was committed and includes the new/updated tests referenced above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c78e7bb18832da64ff62b80674256)