### PR TITLE
Harden external links and Leaflet CDN assets

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -294,6 +294,7 @@
                 <a
                   href="static/pdf/certificates/deutsch_B2_certificate.pdf"
                   target="_blank"
+                  rel="noopener noreferrer"
                   >Confirmation of participation</a
                 >
               </div>
@@ -305,6 +306,7 @@
                 <a
                   href="static/pdf/certificates/deutsch_B1_certificate.pdf"
                   target="_blank"
+                  rel="noopener noreferrer"
                   >Confirmation of participation</a
                 >
               </div>
@@ -316,6 +318,7 @@
                 <a
                   href="static/pdf/certificates/deutsch_A2_certificate.pdf"
                   target="_blank"
+                  rel="noopener noreferrer"
                   >Confirmation of participation</a
                 >
               </div>
@@ -327,6 +330,7 @@
                 <a
                   href="static/pdf/certificates/deutsch_A1_confirmation.pdf"
                   target="_blank"
+                  rel="noopener noreferrer"
                   >Confirmation of participation</a
                 >
               </div>

--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
             <a
               href="https://www.linkedin.com/in/aj-im/"
               target="_blank"
+              rel="noopener noreferrer"
               class="cta-link"
               >LinkedIn →</a
             >
@@ -154,7 +155,11 @@
             <br />You can find all the details of my projects with code on my
             GitHub Profile:
           </p>
-          <a href="https://github.com/joonhaim" class="cta-link" target="_blank"
+          <a
+            href="https://github.com/joonhaim"
+            class="cta-link"
+            target="_blank"
+            rel="noopener noreferrer"
             >GitHub Profile →</a
           >
         </section>

--- a/projects/swiss-hospital-insights/de/index.html
+++ b/projects/swiss-hospital-insights/de/index.html
@@ -65,6 +65,8 @@
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""
     />
     <link rel="stylesheet" href="../assets/css/app.css" />
   </head>
@@ -371,7 +373,11 @@
       <p>&copy; 2025 Adrien Joon‑Ha Im · <a href="../../../">Startseite</a></p>
     </footer>
 
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+      crossorigin=""
+    ></script>
     <script src="../assets/js/app.js"></script>
     <script src="../assets/js/quality-indicators.js"></script>
     <!-- Cloudflare Web Analytics -->

--- a/projects/swiss-hospital-insights/fr/index.html
+++ b/projects/swiss-hospital-insights/fr/index.html
@@ -65,6 +65,8 @@
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""
     />
     <link rel="stylesheet" href="../assets/css/app.css" />
   </head>
@@ -371,7 +373,11 @@
       <p>&copy; 2025 Adrien Joon‑Ha Im · <a href="../../../">Accueil</a></p>
     </footer>
 
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+      crossorigin=""
+    ></script>
     <script src="../assets/js/app.js"></script>
     <script src="../assets/js/quality-indicators.js"></script>
     <!-- Cloudflare Web Analytics -->

--- a/projects/swiss-hospital-insights/index.html
+++ b/projects/swiss-hospital-insights/index.html
@@ -58,6 +58,8 @@
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""
     />
     <link rel="stylesheet" href="assets/css/app.css" />
   </head>
@@ -358,7 +360,11 @@
       <p>&copy; 2025 Adrien Joon‑Ha Im · <a href="../../">Homepage</a></p>
     </footer>
 
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+      crossorigin=""
+    ></script>
     <script src="assets/js/app.js"></script>
     <script src="assets/js/quality-indicators.js"></script>
     <!-- Cloudflare Web Analytics -->

--- a/projects/swiss-hospital-insights/it/index.html
+++ b/projects/swiss-hospital-insights/it/index.html
@@ -65,6 +65,8 @@
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""
     />
     <link rel="stylesheet" href="../assets/css/app.css" />
   </head>
@@ -375,7 +377,11 @@
       <p>&copy; 2025 Adrien Joon‑Ha Im · <a href="../../../">Home</a></p>
     </footer>
 
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+      crossorigin=""
+    ></script>
     <script src="../assets/js/app.js"></script>
     <script src="../assets/js/quality-indicators.js"></script>
     <!-- Cloudflare Web Analytics -->


### PR DESCRIPTION
### Motivation
- Prevent opener-based attacks from pages opened with `target="_blank"` by ensuring opener isolation on all new-tab links. 
- Protect client-side execution from tampered CDN responses by adding Subresource Integrity and CORS attributes to pinned Leaflet assets.

### Description
- Added `rel="noopener noreferrer"` to remaining `target="_blank"` links on the homepage and to the certificate PDF links in `about/index.html`.
- Added `integrity` and `crossorigin` attributes for Leaflet CSS and JS (Leaflet v1.9.4) to `projects/swiss-hospital-insights/index.html` and its `de/`, `fr/`, and `it/` variants so browsers will verify and reject modified CDN resources.
- Kept changes minimal and formatted with the repository's Prettier/linters to match existing style.

### Testing
- Ran `npm run lint` which completed successfully (Prettier, HTMLHint, ESLint; only preexisting JS warnings remain). 
- Executed a custom Python HTML security check that verified every `target="_blank"` link includes `rel="noopener"` and that `unpkg.com` resources include both `integrity` and `crossorigin`, and it passed.
- Ran `git diff --check` and repository linters/formatters as part of validation and they reported no errors.
- Ran the Playwright asset-focused tests with `npx playwright test -g 'assets should'`, which passed, but the full browser-driven Playwright suite could not complete because `npx playwright install chromium` failed to download the Chromium binary (HTTP `403` from `cdn.playwright.dev`).
- Attempts to run `npm audit` and an OSV `/v1/querybatch` dependency check were blocked by HTTP `403` from external advisory endpoints, so dependency advisory coverage is incomplete and should be re-run in CI or a network-enabled environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eca4091f4832db9a7ff2c45f552ca)