### PR TITLE
Refactor Latin project content and styles

### DIFF
--- a/projects/searching-for-poetry-in-latin-prose/index.html
+++ b/projects/searching-for-poetry-in-latin-prose/index.html
@@ -129,7 +129,7 @@
         <section class="latin-features" aria-labelledby="features-title">
           <div class="latin-section-heading">
             <p class="latin-section-label">Capabilities</p>
-            <h2 id="features-title">Key features</h2>
+            <h2 id="features-title">Key Features</h2>
           </div>
           <div class="latin-feature-grid">
             <article>
@@ -185,13 +185,12 @@
         <section class="latin-meters" aria-labelledby="meters-title">
           <div class="latin-section-heading">
             <p class="latin-section-label">Meter support</p>
-            <h2 id="meters-title">Nine metrical forms in one search</h2>
+            <h2 id="meters-title">Supported meters</h2>
+            <p class="latin-section-intro">
+              The search covers hexameter, pentameter, hendecasyllable, and a
+              range of iambic and trochaic forms.
+            </p>
           </div>
-          <p class="latin-section-intro">
-            The tool can detect hexameter, pentameter, hendecasyllable, and a
-            range of iambic and trochaic forms. Its modular structure allows
-            more meters to be added in the future.
-          </p>
           <div class="latin-meter-catalog">
             <article>
               <p class="latin-meter-family">Core forms</p>
@@ -256,25 +255,22 @@
         </section>
 
         <section class="latin-technology" aria-labelledby="technology-title">
-          <p class="latin-section-label">Technology</p>
-          <h2 id="technology-title">
-            An analysis pipeline made accessible on the web
-          </h2>
-          <p class="latin-technology-copy">
-            The final product connects an Angular frontend to a Flask backend
-            and PyTorch model, turning a computational scansion pipeline into a
-            research interface for Latinists without programming experience.
-          </p>
-          <p>
-            <strong>PyTorch</strong> · <strong>Angular</strong> ·
-            <strong>TypeScript</strong> · <strong>Flask</strong> ·
-            <strong>Python</strong> · <strong>GitHub Projects</strong> ·
-            <strong>Scrum</strong>
-          </p>
+          <div class="latin-section-heading">
+            <p class="latin-section-label">Technology</p>
+            <h2 id="technology-title">Stack and contribution</h2>
+          </div>
+          <ul class="latin-tech-list" aria-label="Technologies used">
+            <li>PyTorch</li>
+            <li>Angular</li>
+            <li>TypeScript</li>
+            <li>Flask</li>
+            <li>Python</li>
+            <li>GitHub Projects</li>
+            <li>Scrum</li>
+          </ul>
           <p class="latin-contribution">
-            Personal contribution: my work focused on the Angular application
-            structure, analysis page, filtering and export controls, and overall
-            frontend management.
+            I focused on the Angular frontend, including the analysis workspace,
+            filtering, export controls, and interface structure.
           </p>
         </section>
       </main>

--- a/static/css/pages/latin.css
+++ b/static/css/pages/latin.css
@@ -158,16 +158,16 @@
 }
 
 .latin-section-heading {
-  display: grid;
-  grid-template-columns: minmax(180px, 0.4fr) minmax(0, 1fr);
-  align-items: end;
-  gap: 2rem;
+  max-width: 760px;
   margin-bottom: 2rem;
   padding-bottom: 1.25rem;
   border-bottom: 1px solid var(--latin-line);
 }
 
-.latin-section-heading .latin-section-label,
+.latin-section-heading .latin-section-label {
+  margin-bottom: 0.65rem;
+}
+
 .latin-section-heading h2 {
   margin-bottom: 0;
 }
@@ -223,12 +223,12 @@
 }
 
 .latin-section-intro {
-  max-width: 700px;
-  margin: 0 0 1.75rem auto;
+  max-width: 620px;
+  margin: 0.85rem 0 0;
   color: var(--latin-muted);
   font-family: var(--latin-serif);
   font-size: 1.1rem;
-  line-height: 1.75;
+  line-height: 1.65;
 }
 
 .latin-meter-catalog {
@@ -329,44 +329,39 @@
 }
 
 .latin-technology {
-  padding: clamp(2rem, 6vw, 4rem);
-  border-radius: 18px;
-  background: var(--latin-navy);
+  padding-top: clamp(2rem, 5vw, 3.25rem);
+  border-top: 1px solid var(--latin-line);
 }
 
-.latin-technology .latin-section-label {
-  color: #e4b8c6;
+.latin-technology .latin-section-heading {
+  margin-bottom: 1.5rem;
+  padding-bottom: 0;
+  border-bottom: 0;
 }
 
-.latin-project .latin-technology h2 {
-  max-width: 680px;
-  color: #fff;
+.latin-tech-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem 1.1rem;
+  max-width: 760px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
-.latin-technology > p:not(.latin-section-label):not(.latin-contribution) {
-  max-width: 850px;
-  color: #ccd5e3;
-  font-family: var(--latin-serif);
-  font-size: clamp(1rem, 2vw, 1.15rem);
-  line-height: 1.8;
-}
-
-.latin-technology-copy {
-  margin-bottom: 1rem;
-}
-
-.latin-technology strong {
-  color: #fff;
-  font-weight: 600;
+.latin-tech-list li {
+  padding-bottom: 0.28rem;
+  border-bottom: 1px solid var(--latin-line);
+  color: var(--latin-ink);
+  font-size: 0.95rem;
+  font-weight: 700;
 }
 
 .latin-contribution {
-  max-width: 760px;
-  margin-top: 1.5rem;
-  padding-top: 1.25rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.2);
-  color: #aebbd0;
-  font-size: 0.88rem;
+  max-width: 620px;
+  margin-top: 1.4rem;
+  color: var(--latin-muted);
+  font-size: 0.95rem;
   line-height: 1.65;
 }
 
@@ -377,7 +372,6 @@
 
   .latin-facts,
   .latin-story,
-  .latin-section-heading,
   .latin-filters {
     grid-template-columns: 1fr;
   }
@@ -408,10 +402,6 @@
     font-size: 0.82rem;
   }
 
-  .latin-section-heading {
-    gap: 0.5rem;
-  }
-
   .latin-feature-grid article {
     display: grid;
     grid-template-columns: 2rem minmax(0, 1fr);
@@ -433,10 +423,6 @@
   .latin-feature-grid p {
     grid-column: 2;
     font-size: 0.9rem;
-  }
-
-  .latin-section-intro {
-    margin-left: 0;
   }
 
   .latin-meter-catalog article + article {
@@ -507,8 +493,7 @@
 .latin-showcase,
 .latin-feature-grid article,
 .latin-meter-catalog,
-.latin-filter-groups,
-.latin-contribution {
+.latin-filter-groups {
   border-radius: 0;
   box-shadow: none;
 }


### PR DESCRIPTION
Tweak copy and markup for the Latin project page and adjust related CSS. HTML changes: capitalize "Key Features", replace the meters heading with "Supported meters" and add a short intro paragraph; rework the Technology section into a "Stack and contribution" heading, replace inline strong list with a semantic unordered list of technologies, and shorten the contribution blurb. CSS changes: simplify and tighten .latin-section-heading layout, adjust .latin-section-intro max-width and line-height, remove the navy background for .latin-technology in favor of a top border, add styles for .latin-tech-list and list items, refine .latin-contribution sizing and spacing, and clean up several responsive rules to match the new structure.